### PR TITLE
first try to simplify the shutdown thread for decommissioning 

### DIFF
--- a/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManager.scala
@@ -1823,11 +1823,11 @@ private[spark] class BlockManager(
   }
 
   /*
-   *  Returns the last migration time and a boolean denoting if all the blocks have been migrated.
+   *  Returns a boolean indicating if all the blocks have been migrated.
    *  If there are any tasks running since that time the boolean may be incorrect.
    */
-  private[spark] def lastMigrationInfo(): (Long, Boolean) = {
-    decommissioner.map(_.lastMigrationInfo()).getOrElse((0, false))
+  private[spark] def migrationFinished(): Boolean = {
+    decommissioner.map(_.migrationFinished).getOrElse(true)
   }
 
   private[storage] def getMigratableRDDBlocks(): Seq[ReplicateBlock] =

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -356,29 +356,9 @@ private[storage] class BlockManagerDecommissioner(
   }
 
   /*
-   *  Returns the last migration time and a boolean for if all blocks have been migrated.
-   *  The last migration time is calculated to be the minimum of the last migration of any
-   *  running migration (and if there are now current running migrations it is set to current).
-   *  This provides a timeStamp which, if there have been no tasks running since that time
-   *  we can know that all potential blocks that can be have been migrated off.
+   *  Returns a boolean if all blocks have been migrated
    */
-  private[storage] def lastMigrationInfo(): (Long, Boolean) = {
-    if (stopped || (stoppedRDD && stoppedShuffle)) {
-      (System.nanoTime(), true)
-    } else {
-      // Chose the min of the active times. See the function description for more information.
-      val lastMigrationTime = if (!stoppedRDD && !stoppedShuffle) {
-        Math.min(lastRDDMigrationTime, lastShuffleMigrationTime)
-      } else if (!stoppedShuffle) {
-        lastShuffleMigrationTime
-      } else {
-        lastRDDMigrationTime
-      }
-
-      // Technically we could have blocks left if we encountered an error, but those blocks will
-      // never be migrated, so we don't care about them.
-      val blocksMigrated = (!shuffleBlocksLeft || stoppedShuffle) && (!rddBlocksLeft || stoppedRDD)
-      (lastMigrationTime, blocksMigrated)
-    }
+  private[storage] def migrationFinished(): Boolean = {
+    return stopped || ((!shuffleBlocksLeft || stoppedShuffle) && (!rddBlocksLeft || stoppedRDD));
   }
 }

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerDecommissioner.scala
@@ -43,8 +43,6 @@ private[storage] class BlockManagerDecommissioner(
     conf.get(config.STORAGE_DECOMMISSION_MAX_REPLICATION_FAILURE_PER_BLOCK)
 
   // Used for tracking if our migrations are complete.
-  @volatile private var lastRDDMigrationTime: Long = 0
-  @volatile private var lastShuffleMigrationTime: Long = 0
   @volatile private var rddBlocksLeft: Boolean = true
   @volatile private var shuffleBlocksLeft: Boolean = true
 
@@ -156,7 +154,6 @@ private[storage] class BlockManagerDecommissioner(
           val startTime = System.nanoTime()
           logDebug("Attempting to replicate all cached RDD blocks")
           rddBlocksLeft = decommissionRddCacheBlocks()
-          lastRDDMigrationTime = startTime
           logInfo("Attempt to replicate all cached blocks done")
           logInfo(s"Waiting for ${sleepInterval} before refreshing migrations.")
           Thread.sleep(sleepInterval)
@@ -186,7 +183,6 @@ private[storage] class BlockManagerDecommissioner(
           logDebug("Attempting to replicate all shuffle blocks")
           val startTime = System.nanoTime()
           shuffleBlocksLeft = refreshOffloadingShuffleBlocks()
-          lastShuffleMigrationTime = startTime
           logInfo("Done starting workers to migrate shuffle blocks")
           Thread.sleep(sleepInterval)
         } catch {


### PR DESCRIPTION
Here shutdown thread does the following three steps one by one before triggering the exit for the executor:
- give time to process `DecommissionExecutor` for the driver
- wait for all tasks to finish
- wait for migration to finish

Disclaimer: this change main purpose to help in our discussion and it is just slightly tested, `BlockManagerDecommissionIntegrationSuite` runs successfully:

```
[info] BlockManagerDecommissionIntegrationSuite:
[info] - verify that an already running task which is going to cache data succeeds on a decommissioned executor after task start (8 seconds, 651 milliseconds)
[info] - verify that an already running task which is going to cache data succeeds on a decommissioned executor after one task ends but before job ends (5 seconds, 608 milliseconds)
[info] - verify that shuffle blocks are migrated (5 seconds, 942 milliseconds)
[info] - verify that both migrations can work at the same time (5 seconds, 562 milliseconds)
```