### PR TITLE
Add retry logic for transient Docker registry/daemon errors

### DIFF
--- a/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
+++ b/connector/docker-integration-tests/src/test/scala/org/apache/spark/sql/jdbc/DockerJDBCIntegrationSuite.scala
@@ -119,6 +119,43 @@ abstract class DockerJDBCIntegrationSuite
   private var pulled: Boolean = false
   protected var jdbcUrl: String = _
 
+  // Number of retry attempts for transient Docker registry / daemon errors
+  // (e.g. 5xx responses from Docker Hub, which can be flaky in CI).
+  private val dockerOpMaxAttempts =
+    sys.props.getOrElse("spark.test.docker.retryAttempts", "5").toInt
+  private val dockerOpInitialBackoffMs =
+    sys.props.getOrElse("spark.test.docker.retryInitialBackoffMs", "2000").toLong
+
+  /**
+   * Retry a Docker operation that may transiently fail due to registry / daemon
+   * availability issues (HTTP 5xx, network glitches, etc.). Uses exponential backoff.
+   */
+  private def retryOnDockerError[T](description: String)(op: => T): T = {
+    var attempt = 1
+    var backoff = dockerOpInitialBackoffMs
+    var lastError: Throwable = null
+    while (attempt <= dockerOpMaxAttempts) {
+      try {
+        return op
+      } catch {
+        case NonFatal(e) =>
+          lastError = e
+          if (attempt == dockerOpMaxAttempts) {
+            log.error(
+              s"Docker operation '$description' failed after $attempt attempt(s); giving up.", e)
+          } else {
+            log.warn(
+              s"Docker operation '$description' failed on attempt $attempt of " +
+                s"$dockerOpMaxAttempts; retrying in ${backoff}ms.", e)
+            Thread.sleep(backoff)
+            backoff = math.min(backoff * 2, 30000L)
+          }
+      }
+      attempt += 1
+    }
+    throw lastError
+  }
+
   override def beforeAll(): Unit = runIfTestsEnabled(s"Prepare for ${this.getClass.getName}") {
     super.beforeAll()
     try {
@@ -140,17 +177,23 @@ abstract class DockerJDBCIntegrationSuite
         // Ensure that the Docker image is installed:
         docker.inspectImageCmd(db.imageName).exec()
       } catch {
-        case e: NotFoundException =>
+        case _: NotFoundException =>
           log.warn(s"Docker image ${db.imageName} not found; pulling image from registry")
-          docker.pullImageCmd(db.imageName)
-            .start()
-            .awaitCompletion(connectionTimeout.value.toSeconds, TimeUnit.SECONDS)
+          retryOnDockerError(s"pull image ${db.imageName}") {
+            docker.pullImageCmd(db.imageName)
+              .start()
+              .awaitCompletion(connectionTimeout.value.toSeconds, TimeUnit.SECONDS)
+          }
           pulled = true
       }
 
-      docker.pullImageCmd(db.imageName)
-        .start()
-        .awaitCompletion(connectionTimeout.value.toSeconds, TimeUnit.SECONDS)
+      // Re-pull to ensure we have the latest version of the image. The registry
+      // (e.g. Docker Hub) is occasionally flaky in CI with 5xx responses, so retry.
+      retryOnDockerError(s"pull image ${db.imageName}") {
+        docker.pullImageCmd(db.imageName)
+          .start()
+          .awaitCompletion(connectionTimeout.value.toSeconds, TimeUnit.SECONDS)
+      }
 
       val hostConfig = HostConfig
         .newHostConfig()


### PR DESCRIPTION
## Summary
This change adds resilient retry logic to Docker operations in the JDBC integration test suite to handle transient failures from Docker registries and daemons, which can be flaky in CI environments.

## Key Changes
- Added `retryOnDockerError()` helper method that implements exponential backoff retry logic for Docker operations
- Configurable retry behavior via system properties:
  - `spark.test.docker.retryAttempts`: Maximum number of retry attempts (default: 5)
  - `spark.test.docker.retryInitialBackoffMs`: Initial backoff duration in milliseconds (default: 2000ms)
- Wrapped Docker image pull operations with retry logic to handle transient HTTP 5xx responses and network glitches
- Exponential backoff strategy with a maximum backoff cap of 30 seconds
- Improved logging with warnings on transient failures and errors on final failure

## Implementation Details
- The retry mechanism uses exponential backoff, doubling the backoff duration after each failed attempt (capped at 30 seconds)
- Non-fatal exceptions are caught and retried; the last exception is thrown if all attempts are exhausted
- Both the initial image inspection pull (when image not found) and the subsequent re-pull operation are now wrapped with retry logic
- The change maintains backward compatibility through configurable system properties with sensible defaults

https://claude.ai/code/session_01Py9jZBMMdNaCBJ4vvHc3kd