### PR TITLE
Skip mypy following of pydantic to avoid 0.991 JsonValue crash

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -166,6 +166,12 @@ ignore_missing_imports = True
 [mypy-grpc.*]
 ignore_missing_imports = True
 
+; pydantic is pulled in transitively (e.g. via mlflow). mypy 0.991 crashes
+; serializing pydantic v2's recursive JsonValue type, so skip following it.
+[mypy-pydantic.*]
+ignore_missing_imports = True
+follow_imports = skip
+
 ; Ignore errors for proto generated code
 [mypy-pyspark.sql.connect.proto.*, pyspark.sql.connect.proto]
 ignore_errors = True


### PR DESCRIPTION
mypy 0.991 (pinned for Python 3.8/3.9 support on this branch) crashes during cache serialization on pydantic v2's recursive JsonValue type. pydantic isn't a direct PySpark dep but gets pulled in transitively via mlflow in the lint env. follow_imports = skip prevents mypy from analyzing pydantic at all, sidestepping the assertion.
