### PR TITLE
[SPARK-55206] Add comprehensive UDF transpilation tests and edge case handling

### DIFF
--- a/dev/sparktestsupport/modules.py
+++ b/dev/sparktestsupport/modules.py
@@ -623,6 +623,7 @@ pyspark_sql = Module(
         "pyspark.sql.tests.test_udf_combinations",
         "pyspark.sql.tests.test_udf_profiler",
         "pyspark.sql.tests.test_udf_transpile_hypothesis",
+        "pyspark.sql.tests.test_udf_transpile_parity",
         "pyspark.sql.tests.test_udf_transpile_unit",
         "pyspark.sql.tests.test_unified_udf",
         "pyspark.sql.tests.test_udtf",

--- a/python/pyspark/sql/tests/test_udf_transpile_hypothesis.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_hypothesis.py
@@ -129,18 +129,6 @@ if _have_hypothesis:
     _long_strategy = st.one_of(
         st.none(), st.integers(min_value=-_LONG_BOUND, max_value=_LONG_BOUND)
     )
-    # `square` does ``x ** 2``. Spark's ``Column.__pow__`` returns a
-    # DoubleType, so the squared value has to stay within ``2**53`` (the
-    # largest integer that double precision can represent exactly) for
-    # the cast back to LongType to be lossless. ``2**26`` squared is
-    # ``2**52``, comfortably under that ceiling. Anything bigger and
-    # we'd start chasing off-by-one differences that aren't really
-    # transpilation bugs -- they're double rounding -- so we leave that
-    # gap (proper integer ** lowering) to a follow-up.
-    _SQUARE_BOUND = 2**26
-    _square_strategy = st.one_of(
-        st.none(), st.integers(min_value=-_SQUARE_BOUND, max_value=_SQUARE_BOUND)
-    )
     _bool_strategy = st.one_of(st.none(), st.booleans())
 
     # ---- Edge-case seeds (scalacheck-style) -----------------------------
@@ -151,7 +139,6 @@ if _have_hypothesis:
     # runs. These are the values we always want to try, before random
     # generation kicks in.
     _LONG_EDGES = (None, 0, 1, -1, 7, -7, _LONG_BOUND, -_LONG_BOUND)
-    _SQUARE_EDGES = (None, 0, 1, -1, _SQUARE_BOUND, -_SQUARE_BOUND)
     # Bool space is exhaustive (only three values) so the @example
     # decorators here serve more as documentation of the NULL handling
     # we care about than as new coverage on top of hypothesis's
@@ -259,13 +246,6 @@ def times_three(x):
     # Exercises ast.Mult.
     if x is not None:
         return x * 3
-
-
-def square(x):
-    # Exercises ast.Pow. Inputs are bounded by ``_square_strategy`` so
-    # the squared value stays in the LongType range under ANSI overflow.
-    if x is not None:
-        return x**2
 
 
 def negate_truthy(x):
@@ -514,14 +494,6 @@ class UDFTranspileHypothesisTests(ReusedSQLTestCase):
             df = self._single_arg_df(value, LongType())
             transpiled, interpreted = self._run(times_three, LongType(), df, "a")
             self.assertEqual(transpiled, interpreted, f"times_three mismatch on {value!r}")
-
-        @_hyp_settings
-        @given(value=_square_strategy)
-        @_seed_examples(_SQUARE_EDGES)
-        def test_square_matches_python(self, value):
-            df = self._single_arg_df(value, LongType())
-            transpiled, interpreted = self._run(square, LongType(), df, "a")
-            self.assertEqual(transpiled, interpreted, f"square mismatch on {value!r}")
 
         @_hyp_settings
         @given(value=_bool_strategy)

--- a/python/pyspark/sql/tests/test_udf_transpile_parity.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_parity.py
@@ -34,12 +34,12 @@ the transpiler directly live in ``test_udf_transpile_unit.py`` and
 ``test_udf_transpile_hypothesis.py``.
 
 Note on configuration: enabling transpilation requires ANSI mode, so an "on"
-run is unavoidably also an ANSI run. A handful of inherited tests are overridden
-with a documented ``unittest.skip`` because they assert non-ANSI semantics or
-observe Python-side execution that transpilation legitimately bypasses (e.g. a
-trivially simple UDF that gets rewritten into native Catalyst). Those skips do
-not change the inherited test bodies; the same tests still run in the default
-"off" suites.
+run is unavoidably also an ANSI run. All inherited tests currently pass as-is
+under this configuration, so no per-test overrides are defined here. If a future
+change makes an inherited test diverge purely due to ANSI semantics or because
+transpilation bypasses a Python-side effect (rather than a genuine result
+change), override it here with a documented ``unittest.skip`` rather than
+editing the inherited test body.
 """
 
 import unittest

--- a/python/pyspark/sql/tests/test_udf_transpile_parity.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_parity.py
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Parity tests that re-run the existing UDF test suites with Python-to-Catalyst
+transpilation enabled.
+
+Transpilation is only attempted when both
+``spark.sql.experimental.optimizer.transpilePyUDFs`` and
+``spark.sql.ansi.enabled`` are true, and it is designed to fall back to
+interpreted Python rather than risk semantic drift. These classes re-run the
+shared UDF mixins under that configuration so we can confirm that turning on the
+experimental feature does not change UDF results compared with the default
+(transpilation off) runs covered by the original concrete classes
+(``UDFTests``, ``UDFCombinationsTests``, ``UnifiedUDFTests``).
+
+Transpilation is currently only supported in regular (non-Connect) Spark, so
+these classes are guarded with ``is_remote_only()`` and are intentionally not
+inherited into the Spark Connect parity tests. The companion suites that test
+the transpiler directly live in ``test_udf_transpile_unit.py`` and
+``test_udf_transpile_hypothesis.py``.
+
+Note on configuration: enabling transpilation requires ANSI mode, so an "on"
+run is unavoidably also an ANSI run. A handful of inherited tests are overridden
+with a documented ``unittest.skip`` because they assert non-ANSI semantics or
+observe Python-side execution that transpilation legitimately bypasses (e.g. a
+trivially simple UDF that gets rewritten into native Catalyst). Those skips do
+not change the inherited test bodies; the same tests still run in the default
+"off" suites.
+"""
+
+import unittest
+
+from pyspark.sql.tests.test_udf import BaseUDFTestsMixin
+from pyspark.sql.tests.test_udf_combinations import UDFCombinationsTestsMixin
+from pyspark.sql.tests.test_unified_udf import UnifiedUDFTestsMixin
+from pyspark.testing.sqlutils import ReusedSQLTestCase
+from pyspark.testing.utils import (
+    have_pandas,
+    have_pyarrow,
+    pandas_requirement_message,
+    pyarrow_requirement_message,
+)
+from pyspark.util import is_remote_only
+
+
+# Transpilation is gated on both of these being enabled, both at UDF
+# construction time (python/pyspark/sql/udf.py) and again in the Catalyst
+# optimizer (the ConvertToCatalyst rule).
+_TRANSPILE_CONF = {
+    "spark.sql.experimental.optimizer.transpilePyUDFs": "true",
+    "spark.sql.ansi.enabled": "true",
+}
+
+_NON_CONNECT_ONLY = "UDF transpilation is only supported in regular (non-Connect) Spark."
+
+
+def _enable_transpilation(cls):
+    for key, value in _TRANSPILE_CONF.items():
+        cls.spark.conf.set(key, value)
+
+
+@unittest.skipIf(is_remote_only(), _NON_CONNECT_ONLY)
+class TranspiledUDFParityTests(BaseUDFTestsMixin, ReusedSQLTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(BaseUDFTestsMixin, cls).setUpClass()
+        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "false")
+        _enable_transpilation(cls)
+
+
+@unittest.skipIf(is_remote_only(), _NON_CONNECT_ONLY)
+class TranspiledUDFCombinationsParityTests(UDFCombinationsTestsMixin, ReusedSQLTestCase):
+    @classmethod
+    def setUpClass(cls):
+        ReusedSQLTestCase.setUpClass()
+        cls.spark.conf.set("spark.sql.execution.pythonUDF.arrow.enabled", "false")
+        _enable_transpilation(cls)
+
+
+@unittest.skipIf(is_remote_only(), _NON_CONNECT_ONLY)
+@unittest.skipIf(
+    not have_pandas or not have_pyarrow,
+    pandas_requirement_message or pyarrow_requirement_message,
+)
+class TranspiledUnifiedUDFParityTests(UnifiedUDFTestsMixin, ReusedSQLTestCase):
+    @classmethod
+    def setUpClass(cls):
+        ReusedSQLTestCase.setUpClass()
+        _enable_transpilation(cls)
+
+
+if __name__ == "__main__":
+    from pyspark.testing import main
+
+    main()

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -28,6 +28,7 @@ import unittest
 
 from pyspark.sql import Row
 from pyspark.sql.types import (
+    BinaryType,
     BooleanType,
     DoubleType,
     LongType,
@@ -1203,6 +1204,52 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self.assertFalse(
                 UserDefinedFunction(plus_one, LongType(), deterministic=False).transpiled
             )
+
+    def test_udf_transpile_bool_and_binary_params(self):
+        # bool/bytes annotations map to the "bool"/"binary" categories and match
+        # Boolean/Binary columns. Identity and same-category comparison transpile
+        # (and match Python); boolean arithmetic has no lowering and falls back.
+        def bool_ident(x: bool):
+            return x
+
+        def bool_lt(a: bool, b: bool):
+            return (a < b) if a is not None and b is not None else None
+
+        def bool_add(x: bool):
+            return x + 1  # no boolean arithmetic lowering -> fall back
+
+        def bytes_ident(x: bytes):
+            return x
+
+        self.assertEqual(
+            self._vals(bool_ident, BooleanType(), "a boolean", [(True,), (False,), (None,)]),
+            [True, False, None],
+        )
+        self.assertEqual(
+            self._vals(
+                bool_lt,
+                BooleanType(),
+                "a boolean, b boolean",
+                [(False, True), (True, False), (True, True)],
+            ),
+            [True, False, False],
+        )
+        with self.sql_conf(_TRANSPILE_ON):
+            self.assertFalse(UserDefinedFunction(bool_add, LongType()).transpiled)
+            self.assertTrue(UserDefinedFunction(bytes_ident, BinaryType()).transpiled)
+
+    def test_param_category_combos_caps_preserve_typed_pins(self):
+        # With more than three untyped params the cap collapses the untyped ones
+        # to numeric/string but keeps each typed param pinned (here a: str).
+        import ast as _ast
+
+        from pyspark.sql.transpile import _param_category_combos
+
+        fn = _ast.parse("def f(a: str, b, c, d, e): return a").body[0]
+        combos = _param_category_combos(fn, ["a", "b", "c", "d", "e"])
+        self.assertEqual(len(combos), 2)
+        for combo in combos:
+            self.assertEqual(combo[0], "string")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -38,6 +38,15 @@ from pyspark.testing.sqlutils import ReusedSQLTestCase
 from pyspark.util import is_remote_only
 
 
+# Both flags must be on for the transpiler to attempt a rewrite (at UDF
+# construction time and again in the optimizer); ANSI is required because
+# transpilation targets ANSI semantics.
+_TRANSPILE_ON = {
+    "spark.sql.experimental.optimizer.transpilePyUDFs": True,
+    "spark.sql.ansi.enabled": True,
+}
+
+
 @unittest.skipIf(
     is_remote_only(),
     "UDF transpilation is only supported in regular (non-Connect) Spark.",
@@ -867,6 +876,415 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         # as ``a`` (unresolved) or with a backtick variant, so we just
         # require the column name appears somewhere in the message.
         self.assertIn("a", message)
+
+    # ------------------------------------------------------------------
+    # Edge cases (SPARK-55206 follow-up). Behaviors below were confirmed
+    # against the running transpiler; fallbacks are locked in as the safe
+    # contract. Note: ordering comparisons emit a ``raise_error`` whose
+    # message literal contains "UDF", so plan-elision checks count
+    # ``EvalPython`` nodes rather than the "UDF" substring.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _eval_python_count(df):
+        plan = df._jdf.queryExecution().executedPlan().toString()
+        return plan.count("EvalPython")
+
+    def test_udf_transpile_modulo_sign_parity(self):
+        # Python's ``%`` takes the sign of the divisor; Spark's ``%`` takes
+        # the sign of the dividend. The transpiler rewrites ``a % b`` as
+        # ``sign(b) * pmod(sign(b) * a, abs(b))`` so the result matches
+        # Python for negative operands. Pin that parity deterministically
+        # (the hypothesis suite that fuzzes this is gated behind
+        # RUN_HYPOTHESIS and skips in normal runs).
+        def py_mod(x, y):
+            if x is not None and y is not None:
+                return x % y
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(py_mod, LongType())
+            self.assertTrue(pudf.transpiled, "two-arg modulo should transpile")
+            for a, b in [(7, 3), (7, -3), (-7, 3), (-7, -3), (0, 3), (5, -5), (-8, 3)]:
+                with self.subTest(a=a, b=b):
+                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
+                    self.assertEqual(
+                        df.select(pudf("a", "b")).first()[0],
+                        a % b,
+                        f"{a} % {b} should match Python semantics",
+                    )
+
+    def test_udf_transpile_binary_arithmetic_param_order(self):
+        # ``-``, ``*``, ``**`` lower to the matching Column ops. The two-arg
+        # non-commutative cases also prove parameter order is preserved
+        # (a -> _udf_param_0, b -> _udf_param_1), not swapped.
+        def sub_ab(a, b):
+            if a is not None and b is not None:
+                return a - b
+
+        def mul_ab(a, b):
+            if a is not None and b is not None:
+                return a * b
+
+        def square(x):
+            if x is not None:
+                return x ** 2
+
+        with self.sql_conf(_TRANSPILE_ON):
+            sub_udf = UserDefinedFunction(sub_ab, LongType())
+            mul_udf = UserDefinedFunction(mul_ab, LongType())
+            sq_udf = UserDefinedFunction(square, LongType())
+            self.assertTrue(sub_udf.transpiled and mul_udf.transpiled and sq_udf.transpiled)
+            for a, b, expected in [(5, 3, 2), (3, 5, -2), (0, 7, -7)]:
+                with self.subTest(op="sub", a=a, b=b):
+                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
+                    self.assertEqual(df.select(sub_udf("a", "b")).first()[0], expected)
+            for a, b, expected in [(4, 3, 12), (-2, 5, -10)]:
+                with self.subTest(op="mul", a=a, b=b):
+                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
+                    self.assertEqual(df.select(mul_udf("a", "b")).first()[0], expected)
+            for x, expected in [(6, 36), (-3, 9), (0, 0)]:
+                with self.subTest(op="pow", x=x):
+                    df = self.spark.createDataFrame([(x,)], "a long")
+                    self.assertEqual(df.select(sq_udf("a")).first()[0], expected)
+
+    def test_udf_transpile_assigned_lambda_transpiles(self):
+        # A lambda bound to a name parses as ``Assign(value=Lambda)``, which
+        # the extractor handles, so it transpiles.
+        adder = lambda v: v + 1  # noqa: E731
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(adder, LongType())
+            self.assertTrue(pudf.transpiled, "assigned lambda should transpile")
+            df = self.spark.createDataFrame([(1,), (10,)], "a long")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [2, 11])
+
+    def test_udf_transpile_inline_and_wrapped_lambda_fall_back(self):
+        # ``inspect.getsource`` on an inline or wrapped lambda returns the
+        # enclosing ``Assign(value=Call(...))``; the extractor has no
+        # ``ast.Call`` branch, so these fall back to interpreted Python (the
+        # docstring's "wrapped lambda" support is aspirational). Each must
+        # still compute the correct value.
+        import functools
+
+        def wrapper(fn):
+            return fn
+
+        with self.sql_conf(_TRANSPILE_ON):
+            inline = UserDefinedFunction(lambda v: v + 1, LongType())
+            self.assertEqual([], inline.transpiled, "inline lambda must fall back")
+
+            wrapped = UserDefinedFunction(wrapper(lambda v: v + 1), LongType())
+            self.assertEqual([], wrapped.transpiled, "wrapped lambda must fall back")
+
+            base = lambda v, w: v + w  # noqa: E731
+            partial = UserDefinedFunction(functools.partial(base, 1), LongType())
+            self.assertEqual([], partial.transpiled, "functools.partial must fall back")
+
+            df = self.spark.createDataFrame([(4,)], "a long")
+            self.assertEqual(df.select(inline("a")).first()[0], 5)
+            self.assertEqual(df.select(wrapped("a")).first()[0], 5)
+            self.assertEqual(df.select(partial("a")).first()[0], 5)
+
+    def test_udf_transpile_callable_object_multi_arg(self):
+        # A callable instance carries ``self`` as the first parameter; the
+        # extractor offsets it so ``a``/``b`` map to _udf_param_0/_udf_param_1.
+        # A non-commutative body proves both the offset and the order.
+        class SubAB:
+            def __call__(self, a, b):
+                if a is not None and b is not None:
+                    return a - b
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(SubAB(), LongType())
+            self.assertTrue(pudf.transpiled, "callable object should transpile")
+            for a, b, expected in [(5, 3, 2), (3, 5, -2)]:
+                with self.subTest(a=a, b=b):
+                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
+                    self.assertEqual(df.select(pudf("a", "b")).first()[0], expected)
+
+    def test_udf_transpile_not_of_comparison(self):
+        # ``not (x > 0)`` -- the operand is a Compare (statically boolean), so
+        # ``not`` lowers (the positive control for the bare-``not`` fallbacks).
+        def not_positive(x):
+            if x is not None:
+                return not (x > 0)
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(not_positive, BooleanType())
+            self.assertTrue(pudf.transpiled, "not(comparison) should transpile")
+            df = self.spark.createDataFrame([(1,), (0,), (-1,), (None,)], "a long")
+            self.assertEqual(
+                [r[0] for r in df.select(pudf("a")).collect()],
+                [False, True, True, None],
+            )
+
+    def test_udf_transpile_nested_boolean(self):
+        # Compose and/or over comparisons: ``(x > 0 and y > 0) or z == 0``.
+        def nested(x, y, z):
+            if x is not None and y is not None:
+                return (x > 0 and y > 0) or z == 0
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(nested, BooleanType())
+            self.assertTrue(pudf.transpiled, "nested boolean should transpile")
+            for x, y, z, expected in [
+                (1, 1, 5, True),
+                (-1, 1, 0, True),
+                (-1, 1, 5, False),
+                (1, -1, 9, False),
+            ]:
+                with self.subTest(x=x, y=y, z=z):
+                    df = self.spark.createDataFrame([(x, y, z)], "a long, b long, c long")
+                    self.assertEqual(df.select(pudf("a", "b", "c")).first()[0], expected)
+
+    def test_udf_transpile_string_equality_and_ordering(self):
+        # String columns transpile for ``==`` and ``<`` like numerics do.
+        def eq_foo(x):
+            if x is not None:
+                return x == "foo"
+
+        def lt_m(x):
+            if x is not None:
+                return x < "m"
+
+        with self.sql_conf(_TRANSPILE_ON):
+            eq_udf = UserDefinedFunction(eq_foo, BooleanType())
+            lt_udf = UserDefinedFunction(lt_m, BooleanType())
+            self.assertTrue(eq_udf.transpiled and lt_udf.transpiled)
+            eq_df = self.spark.createDataFrame([("foo",), ("bar",), (None,)], "a string")
+            self.assertEqual(
+                [r[0] for r in eq_df.select(eq_udf("a")).collect()], [True, False, None]
+            )
+            lt_df = self.spark.createDataFrame([("a",), ("z",), (None,)], "a string")
+            self.assertEqual(
+                [r[0] for r in lt_df.select(lt_udf("a")).collect()], [True, False, None]
+            )
+
+    def test_udf_transpile_if_elif_else(self):
+        # ``elif`` is a nested ``If`` in the else slot (one statement), so a
+        # null-safe if/elif/else chain transpiles.
+        def classify(x):
+            if x is None:
+                return -1
+            elif x == 0:
+                return 0
+            else:
+                return 1
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(classify, LongType())
+            self.assertTrue(pudf.transpiled, "if/elif/else should transpile")
+            df = self.spark.createDataFrame([(None,), (0,), (5,), (-3,)], "a long")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [-1, 0, 1, 1])
+
+    def test_udf_transpile_filter_elision(self):
+        # A transpiled boolean UDF used in ``filter`` is elided like one used
+        # in ``select`` (extends coverage beyond projection).
+        def gt5(x):
+            if x is not None:
+                return x > 5
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(gt5, BooleanType())
+            self.assertTrue(pudf.transpiled, "filter predicate should transpile")
+            df = self.spark.createDataFrame([(3,), (7,), (1,), (None,)], "a long")
+            fdf = df.filter(pudf("a"))
+            self.assertEqual([r[0] for r in fdf.collect()], [7])
+            self.assertEqual(
+                0,
+                self._eval_python_count(fdf),
+                "transpiled filter predicate should leave no Python eval node",
+            )
+
+    def test_udf_transpile_mixed_chain_elision(self):
+        # Non-convertible (closure) -> convertible (``x + 1``) -> non-convertible
+        # (``/``). Only the middle UDF is rewritten; it is inlined into the
+        # outer UDF's argument, leaving exactly two Python eval nodes.
+        offset = 3
+
+        def add_offset(x):  # closure -> fallback
+            if x is not None:
+                return x + offset
+
+        def plus_one(x):  # convertible
+            if x is not None:
+                return x + 1
+
+        def div_two(x):  # `/` -> fallback
+            if x is not None:
+                return x / 2
+
+        with self.sql_conf(_TRANSPILE_ON):
+            u1 = UserDefinedFunction(add_offset, LongType())
+            u2 = UserDefinedFunction(plus_one, LongType())
+            u3 = UserDefinedFunction(div_two, DoubleType())
+            self.assertEqual([], u1.transpiled, "closure UDF must fall back")
+            self.assertTrue(u2.transpiled, "middle UDF must transpile")
+            self.assertEqual([], u3.transpiled, "division UDF must fall back")
+            df = self.spark.createDataFrame([(10,)], "a long")
+            chained = (
+                df.select(u1("a").alias("x1"))
+                .select(u2("x1").alias("x2"))
+                .select(u3("x2").alias("x3"))
+            )
+            self.assertEqual(chained.first()[0], 7.0)  # ((10 + 3) + 1) / 2
+            self.assertEqual(
+                2,
+                self._eval_python_count(chained),
+                "only the two non-convertible UDFs should remain as eval nodes",
+            )
+
+    def test_udf_transpile_config_toggle_no_stale_nodes(self):
+        # A UDF built with the flags ON carries a transpiled expression, but
+        # executing it with the flags OFF must fall back cleanly to interpreted
+        # Python (the optimizer drops the transpiled node) -- no stale or
+        # unevaluable plan node, and a correct result.
+        def plus_one(x):
+            if x is not None:
+                return x + 1
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(plus_one, LongType())
+            self.assertTrue(pudf.transpiled, "should transpile while flags are on")
+
+        with self.sql_conf(
+            {
+                "spark.sql.experimental.optimizer.transpilePyUDFs": False,
+                "spark.sql.ansi.enabled": False,
+            }
+        ):
+            df = self.spark.createDataFrame([(1,), (5,)], "a long")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [2, 6])
+
+    def test_udf_transpile_return_type_cast(self):
+        # The lowered expression is cast to the declared return type, so the
+        # output schema and values follow the declared type.
+        def plus_one(x):
+            if x is not None:
+                return x + 1
+
+        with self.sql_conf(_TRANSPILE_ON):
+            double_udf = UserDefinedFunction(plus_one, DoubleType())
+            long_udf = UserDefinedFunction(plus_one, LongType())
+            self.assertTrue(double_udf.transpiled and long_udf.transpiled)
+            df = self.spark.createDataFrame([(1,)], "a long")
+            double_col = df.select(double_udf("a").alias("r"))
+            self.assertEqual(double_col.schema["r"].dataType, DoubleType())
+            self.assertEqual(double_col.first()[0], 2.0)
+            self.assertEqual(df.select(long_udf("a")).first()[0], 2)
+
+    def test_udf_transpile_reversed_operand_comparison(self):
+        # Literal-on-the-left comparisons exercise the asymmetry in
+        # ``_lower_value_compare`` / ``_lower_eq`` (which take the left column
+        # and the right AST node).
+        def lit_lt(x):
+            if x is not None:
+                return 0 < x
+
+        def lit_eq(x):
+            return 5 == x
+
+        def none_eq(x):
+            return None == x  # noqa: E711
+
+        with self.sql_conf(_TRANSPILE_ON):
+            lt_udf = UserDefinedFunction(lit_lt, BooleanType())
+            eq_udf = UserDefinedFunction(lit_eq, BooleanType())
+            none_udf = UserDefinedFunction(none_eq, BooleanType())
+            self.assertTrue(lt_udf.transpiled and eq_udf.transpiled and none_udf.transpiled)
+
+            lt_df = self.spark.createDataFrame([(1,), (0,), (-1,), (None,)], "a long")
+            self.assertEqual(
+                [r[0] for r in lt_df.select(lt_udf("a")).collect()],
+                [True, False, False, None],
+            )
+            eq_df = self.spark.createDataFrame([(5,), (3,), (None,)], "a long")
+            self.assertEqual(
+                [r[0] for r in eq_df.select(eq_udf("a")).collect()],
+                [True, False, False],
+            )
+            none_df = self.spark.createDataFrame([(None,), (5,)], "a long")
+            self.assertEqual(
+                [r[0] for r in none_df.select(none_udf("a")).collect()],
+                [True, False],
+            )
+
+    def test_udf_transpile_column_to_column_ordering(self):
+        # Ordering comparison between two parameters (not a literal).
+        def a_lt_b(a, b):
+            if a is not None and b is not None:
+                return a < b
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(a_lt_b, BooleanType())
+            self.assertTrue(pudf.transpiled, "column-to-column ordering should transpile")
+            for a, b, expected in [(1, 2, True), (2, 1, False), (1, 1, False)]:
+                with self.subTest(a=a, b=b):
+                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
+                    self.assertEqual(df.select(pudf("a", "b")).first()[0], expected)
+
+    def test_udf_transpile_nested_unary(self):
+        # Stacked unary ops: ``- -x`` (USub of USub) and ``+(-x)`` (UAdd of
+        # USub, where UAdd is identity).
+        def double_neg(x):
+            if x is not None:
+                return - -x
+
+        def plus_neg(x):
+            if x is not None:
+                return +(-x)
+
+        with self.sql_conf(_TRANSPILE_ON):
+            dn_udf = UserDefinedFunction(double_neg, LongType())
+            pn_udf = UserDefinedFunction(plus_neg, LongType())
+            self.assertTrue(dn_udf.transpiled and pn_udf.transpiled)
+            df = self.spark.createDataFrame([(5,), (-3,)], "a long")
+            self.assertEqual([r[0] for r in df.select(dn_udf("a")).collect()], [5, -3])
+            self.assertEqual([r[0] for r in df.select(pn_udf("a")).collect()], [-5, 3])
+
+    def test_udf_transpile_constant_body(self):
+        # A body that ignores its parameter and returns a constant lowers to a
+        # literal (no parameter placeholder needed).
+        def always_42(x):
+            return 42
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(always_42, LongType())
+            self.assertTrue(pudf.transpiled, "constant body should transpile")
+            df = self.spark.createDataFrame([(1,), (999,)], "a long")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [42, 42])
+
+    def test_udf_transpile_default_args_fall_back(self):
+        # The positional ``_udf_param_N`` placeholder scheme can't represent
+        # default / variadic / keyword-only arguments: a call site may omit a
+        # defaulted argument, dangling a placeholder past the bound arguments.
+        # Such functions must fall back to interpreted Python (regression for
+        # the INVALID_UDF_PARAMETER_PLACEHOLDER_INDEX failure).
+        def with_default(a, b=0):
+            return a + 10 * b
+
+        def with_varargs(a, *rest):
+            return a
+
+        def with_kwargs(a, **opts):
+            return a
+
+        with self.sql_conf(_TRANSPILE_ON):
+            for label, func in [
+                ("default", with_default),
+                ("varargs", with_varargs),
+                ("kwargs", with_kwargs),
+            ]:
+                with self.subTest(case=label):
+                    pudf = UserDefinedFunction(func, LongType())
+                    self.assertEqual(
+                        [], pudf.transpiled, f"{label}: must fall back, not transpile"
+                    )
+            # The defaulted UDF still works (interpreted), with and without
+            # the optional argument.
+            df = self.spark.createDataFrame([(5,)], "a long")
+            pudf = UserDefinedFunction(with_default, LongType())
+            self.assertEqual(df.select(pudf("a")).first()[0], 5)  # b defaults to 0
+            self.assertEqual(df.select(pudf("a", "a")).first()[0], 55)  # 5 + 10 * 5
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -908,14 +908,13 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
 
     def test_udf_transpile_lowers_operators(self):
         # Operators lower to Catalyst and match Python: modulo sign-parity,
-        # non-commutative -/* (parameter order), **, unary nesting, constant
+        # non-commutative -/* (parameter order), unary nesting, constant
         # body, not(compare), nested boolean, string ==/<, reversed-operand and
         # column-to-column comparisons, if/elif/else, and assigned lambdas.
         L, B = LongType(), BooleanType()
         modulo = lambda x, y: x % y  # noqa: E731
         subtract = lambda a, b: a - b  # noqa: E731
         multiply = lambda a, b: a * b  # noqa: E731
-        power = lambda x: x**2  # noqa: E731
         double_neg = lambda x: --x  # noqa: E731
         unary_pm = lambda x: +(-x)  # noqa: E731
         constant = lambda x: 42  # noqa: E731
@@ -942,7 +941,6 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             (modulo, L, "a long, b long", [(7, 3), (7, -3), (-7, 3), (-7, -3)], [1, -2, 2, -1]),
             (subtract, L, "a long, b long", [(5, 3), (3, 5)], [2, -2]),
             (multiply, L, "a long, b long", [(4, 3), (-2, 5)], [12, -10]),
-            (power, L, "a long", [(6,), (-3,), (0,)], [36, 9, 0]),
             (double_neg, L, "a long", [(5,), (-3,)], [5, -3]),
             (unary_pm, L, "a long", [(5,), (-3,)], [-5, 3]),
             (constant, L, "a long", [(1,), (999,)], [42, 42]),
@@ -1158,13 +1156,53 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             with self.subTest(func=func, schema=schema):
                 self._raises(func, schema, rows, needle="")
 
-    def test_udf_transpile_power_precision_divergence(self):
-        # `**` -> Spark pow (DOUBLE); beyond ~2**53 it loses precision where
-        # Python keeps exact ints. Documented limitation.
+    def test_udf_transpile_power_falls_back(self):
+        # `**` is intentionally not lowered (Spark's pow is DOUBLE and loses
+        # precision for large ints), so a UDF using it falls back to interpreted
+        # Python. TODO(SPARK-55210): revisit once an exact integer-power lowering
+        # exists.
         square = lambda x: x**2  # noqa: E731
-        x = 134217729  # 2**27 + 1; exact square exceeds double's 2**53 range
-        self.assertEqual(self._vals(square, LongType(), "a long", [(x,)]), [18014398777917440])
-        self.assertNotEqual(x * x, 18014398777917440)  # Python's exact value differs
+        with self.sql_conf(_TRANSPILE_ON):
+            self.assertFalse(UserDefinedFunction(square, LongType()).transpiled)
+
+    def test_udf_transpile_non_numeric_constant_falls_back(self):
+        # bool/None constants have no faithful numeric/string lowering, so
+        # arithmetic against them must fall back rather than emit an option that
+        # crashes analysis (`x * True`) or silently returns NULL (`x + None`).
+        mul_bool = lambda x: x * True  # noqa: E731
+        add_none = lambda x: x + None  # noqa: E731
+        with self.sql_conf(_TRANSPILE_ON):
+            self.assertFalse(UserDefinedFunction(mul_bool, LongType()).transpiled)
+            self.assertFalse(UserDefinedFunction(add_none, LongType()).transpiled)
+
+    def test_udf_transpile_mixed_type_comparison_falls_back(self):
+        # Python forbids ordering across types (`a < b` for int/str -> TypeError);
+        # Spark would coerce and return a wrong boolean. A comparison whose
+        # operand categories differ is dropped (so int-vs-str `<` falls back),
+        # while a same-category comparison still transpiles.
+        def lt_mixed(a: int, b: str):
+            return (a < b) if a is not None and b is not None else None
+
+        def lt_same(a: int, b: int):
+            return (a < b) if a is not None and b is not None else None
+
+        with self.sql_conf(_TRANSPILE_ON):
+            self.assertFalse(UserDefinedFunction(lt_mixed, BooleanType()).transpiled)
+            self.assertTrue(UserDefinedFunction(lt_same, BooleanType()).transpiled)
+
+    def test_udf_transpile_skips_nondeterministic(self):
+        # A nondeterministic UDF must not be transpiled: the optimizer could
+        # fold/reorder/duplicate the plain expression, dropping the barrier.
+        # Holds whether marked at construction or via asNondeterministic().
+        plus_one = lambda x: x + 1  # noqa: E731
+        with self.sql_conf(_TRANSPILE_ON):
+            self.assertTrue(UserDefinedFunction(plus_one, LongType()).transpiled)
+            self.assertFalse(
+                UserDefinedFunction(plus_one, LongType()).asNondeterministic().transpiled
+            )
+            self.assertFalse(
+                UserDefinedFunction(plus_one, LongType(), deterministic=False).transpiled
+            )
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -1286,6 +1286,155 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self.assertEqual(df.select(pudf("a")).first()[0], 5)  # b defaults to 0
             self.assertEqual(df.select(pudf("a", "a")).first()[0], 55)  # 5 + 10 * 5
 
+    # ------------------------------------------------------------------
+    # Incorrect-transpilation hazards (correctness audit). Python overloads
+    # +, *, % for text and treats NULL / NaN / overflow differently from
+    # Spark, and the transpiler has no column-type info, so it assumes numeric
+    # operands. String/bytes *literal* operands are now refused (fall back);
+    # the cases that still transpile are pinned here as documented divergences
+    # so a future change to any of them is noticed.
+    # ------------------------------------------------------------------
+
+    def test_udf_transpile_string_literal_operator_overloading_falls_back(self):
+        # Python's +, *, % over text (concatenation, repetition, %-formatting)
+        # are NOT arithmetic. A string/bytes literal operand makes that
+        # statically detectable, so the transpiler falls back rather than emit
+        # a numeric op over text (which Spark would reject or miscompute).
+        def concat_right(a):
+            if a is not None:
+                return a + "!"
+
+        def concat_left(a):
+            if a is not None:
+                return "pre-" + a
+
+        def percent_format(x):
+            if x is not None:
+                return "n=%d" % x
+
+        def repeat(x):
+            if x is not None:
+                return "ab" * x
+
+        with self.sql_conf(_TRANSPILE_ON):
+            cr = UserDefinedFunction(concat_right, StringType())
+            cl = UserDefinedFunction(concat_left, StringType())
+            pf = UserDefinedFunction(percent_format, StringType())
+            rp = UserDefinedFunction(repeat, StringType())
+            for label, pudf in [
+                ("concat_right", cr),
+                ("concat_left", cl),
+                ("percent_format", pf),
+                ("repeat", rp),
+            ]:
+                with self.subTest(case=label):
+                    self.assertEqual([], pudf.transpiled, f"{label}: must fall back")
+            # Interpreted Python still produces the right text.
+            sdf = self.spark.createDataFrame([("hi",)], "a string")
+            self.assertEqual(sdf.select(cr("a")).first()[0], "hi!")
+            self.assertEqual(sdf.select(cl("a")).first()[0], "pre-hi")
+            idf = self.spark.createDataFrame([(5,)], "a long")
+            self.assertEqual(idf.select(pf("a")).first()[0], "n=5")
+            self.assertEqual(idf.select(rp("a")).first()[0], "ababababab")  # "ab" * 5
+
+    def test_udf_transpile_string_column_arithmetic_known_divergence(self):
+        # KNOWN LIMITATION: a string *column* combined with a number can't be
+        # detected statically, so it transpiles and diverges from Python --
+        # Spark coerces the string to a number, while Python would concatenate,
+        # repeat, or raise. Pinned so schema-aware handling (if it ever lands)
+        # trips this test.
+        def col_plus_5(a):
+            if a is not None:
+                return a + 5
+
+        def col_times_3(a):
+            if a is not None:
+                return a * 3
+
+        with self.sql_conf(_TRANSPILE_ON):
+            plus_udf = UserDefinedFunction(col_plus_5, LongType())
+            times_udf = UserDefinedFunction(col_times_3, StringType())
+            self.assertTrue(
+                plus_udf.transpiled and times_udf.transpiled,
+                "string-column arithmetic still transpiles today (no schema info)",
+            )
+            # "10" + 5 -> Spark coerces to 15; interpreted Python raises TypeError.
+            num_df = self.spark.createDataFrame([("10",)], "a string")
+            self.assertEqual(num_df.select(plus_udf("a")).first()[0], 15)
+            # "2" * 3 -> Spark coerces to "6"; interpreted Python gives "222".
+            two_df = self.spark.createDataFrame([("2",)], "a string")
+            self.assertEqual(two_df.select(times_udf("a")).first()[0], "6")
+
+    def test_udf_transpile_unguarded_arithmetic_on_null_known_divergence(self):
+        # KNOWN DIVERGENCE: arithmetic is not null-guarded (unlike the ordering
+        # comparisons, which raise to mirror Python). An UNguarded `x + 1` thus
+        # yields NULL on a NULL input, whereas interpreted Python raises
+        # TypeError (None + 1). Guard with `is not None` for parity.
+        def add_one_unguarded(x):
+            return x + 1
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(add_one_unguarded, LongType())
+            self.assertTrue(pudf.transpiled)
+            df = self.spark.createDataFrame([(None,), (5,)], "a long")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [None, 6])
+
+    def test_udf_transpile_overflow_and_modulo_by_zero_raise(self):
+        # Under ANSI the transpiled arithmetic raises on overflow and on
+        # modulo-by-zero. Interpreted Python would promote `x * x` to a big int
+        # (a divergence; see SPARK-55210), and raises ZeroDivisionError for
+        # `x % 0` (compatible -- both raise).
+        def square(x):
+            if x is not None:
+                return x * x
+
+        def mod_zero(x):
+            if x is not None:
+                return x % 0
+
+        with self.sql_conf(_TRANSPILE_ON):
+            sq = UserDefinedFunction(square, LongType())
+            mz = UserDefinedFunction(mod_zero, LongType())
+            self.assertTrue(sq.transpiled and mz.transpiled)
+            big = self.spark.createDataFrame([(4000000000,)], "a long")  # 4e9^2 overflows long
+            with self.assertRaises(Exception) as ctx:
+                big.select(sq("a")).collect()
+            self.assertIn("OVERFLOW", str(ctx.exception).upper())
+            zero = self.spark.createDataFrame([(5,)], "a long")
+            with self.assertRaises(Exception) as ctx2:
+                zero.select(mz("a")).collect()
+            self.assertIn("ZERO", str(ctx2.exception).upper())
+
+    def test_udf_transpile_nan_comparison_known_divergence(self):
+        # KNOWN DIVERGENCE: Spark orders NaN as greater than every value, so a
+        # transpiled `x > 0` returns True for NaN, whereas interpreted Python
+        # (`nan > 0`) returns False. The null-guard checks isNull, not isNaN.
+        def gt_zero(x):
+            if x is not None:
+                return x > 0
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(gt_zero, BooleanType())
+            self.assertTrue(pudf.transpiled)
+            df = self.spark.createDataFrame([(float("nan"),), (1.0,)], "a double")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [True, True])
+
+    def test_udf_transpile_cross_type_equality_coerces(self):
+        # KNOWN DIVERGENCE: comparing a column to a literal of a different type
+        # coerces in Spark, so a transpiled `x == "5"` on an int column is True
+        # for 5, whereas Python's `5 == "5"` is False (no cross-type coercion).
+        # Equality with a string literal is intentionally NOT forced to fall
+        # back, since `stringcol == "5"` is a legitimate, correct comparison.
+        def eq_str_five(x):
+            if x is not None:
+                return x == "5"
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(eq_str_five, BooleanType())
+            self.assertTrue(pudf.transpiled)
+            df = self.spark.createDataFrame([(5,), (3,)], "a long")
+            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [True, False])
+
 
 if __name__ == "__main__":
     from pyspark.testing import main

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -1036,7 +1036,8 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
     def test_udf_transpile_falls_back(self):
         # Shapes that must NOT transpile (and still compute via Python):
         # inline/wrapped/partial lambdas, default/variadic/keyword-only args, and
-        # string-literal operator overloading (+, %, * over text).
+        # `%` string formatting. (String `+`/`*` now lower to concat/repeat -- see
+        # test_udf_transpile_string_operands -- but `%` as a format is not handled.)
         import functools
 
         def wrapper(fn):
@@ -1052,10 +1053,7 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             return a
 
         base = lambda v, w: v + w  # noqa: E731
-        concat_right = lambda a: a + "!"  # noqa: E731
-        concat_left = lambda a: "pre-" + a  # noqa: E731
         percent_fmt = lambda x: "n=%d" % x  # noqa: E731
-        repeat = lambda x: "ab" * x  # noqa: E731
         with self.sql_conf(_TRANSPILE_ON):
             # inline / wrapped / partial lambdas -> source can't be extracted
             self.assertEqual([], UserDefinedFunction(lambda v: v + 1, LongType()).transpiled)
@@ -1065,23 +1063,16 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self.assertEqual(
                 [], UserDefinedFunction(functools.partial(base, 1), LongType()).transpiled
             )
-            # default / variadic / keyword-only args, and string-literal +/%/* over text
+            # default / variadic / keyword-only args, and `%` string formatting
             for func, rt in [
                 (with_default, LongType()),
                 (with_varargs, LongType()),
                 (with_kwargs, LongType()),
-                (concat_right, StringType()),
-                (concat_left, StringType()),
                 (percent_fmt, StringType()),
-                (repeat, StringType()),
             ]:
                 with self.subTest(func=func):
                     self.assertEqual([], UserDefinedFunction(func, rt).transpiled)
             # Fell back -> interpreted Python still computes correctly.
-            sdf = self.spark.createDataFrame([("hi",)], "a string")
-            self.assertEqual(
-                sdf.select(UserDefinedFunction(concat_right, StringType())("a")).first()[0], "hi!"
-            )
             wd = UserDefinedFunction(with_default, LongType())
             num = self.spark.createDataFrame([(5,)], "a long")
             self.assertEqual(
@@ -1093,7 +1084,8 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         # a future fix is noticed): unguarded arithmetic on NULL yields NULL
         # (Python raises TypeError), NaN > 0 is True (Python False; Spark orders
         # NaN highest), and comparing to a cross-type literal coerces (int == "5"
-        # -> True; Python False). Mixed str/numeric arithmetic raises -- see below.
+        # -> True; Python False). Mixed str/numeric arithmetic is handled or falls
+        # back -- see test_udf_transpile_string_operands{,_fall_back}.
         unguarded = lambda x: x + 1  # noqa: E731
         nan_gt = lambda x: (x > 0) if x is not None else None  # noqa: E731
         eq_strlit = lambda x: (x == "5") if x is not None else None  # noqa: E731
@@ -1105,36 +1097,66 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self._vals(eq_strlit, BooleanType(), "a long", [(5,), (3,)]), [True, False]
         )
 
-    def test_udf_transpile_known_raise_divergences(self):
-        # Transpile but raise where Python differs: overflow under ANSI vs
-        # Python's big int (SPARK-55210), and `% 0` (both raise, compatible).
+    def test_udf_transpile_overflow_and_modulo_zero_raise(self):
+        # Transpiled arithmetic that raises at runtime: `*` overflow raises under
+        # ANSI where Python promotes to a big int (a real divergence, SPARK-55210),
+        # while `% 0` raises in both Spark and Python (compatible -- pinned here so
+        # it isn't mistaken for a divergence).
         overflow = lambda x: x * x  # noqa: E731
         modulo_zero = lambda x: x % 0  # noqa: E731
         self._raises(overflow, "a long", [(4000000000,)], "overflow")
         self._raises(modulo_zero, "a long", [(5,)], "zero")
 
-    def test_udf_transpile_mixed_string_numeric_operands_raise(self):
-        # The transpiler can't see column types, so for any non-constant operand
-        # it emits a runtime numeric guard: a string/binary column in arithmetic
-        # raises loudly rather than let Spark silently coerce it (the literal
-        # guard alone can't catch a string passed as a *column*). These str/numeric
-        # mixes -- str and int as separate UDF params included -- must raise, not
-        # miscompute (Python would concatenate, repeat, format, or raise TypeError).
+    def test_udf_transpile_string_operands(self):
+        # Textual `+`/`*` lower to Catalyst string ops and match Python: `str +
+        # str` -> concat, and `str * int` / `int * str` -> repeat (including a
+        # string column times a numeric literal). The transpiler emits a string-
+        # typed variant whose declared categories the JVM matches against the bound
+        # column types (see UserDefinedPythonFunction.builder).
+        S = StringType()
+        add = lambda a, b: a + b  # noqa: E731
+        mul = lambda a, b: a * b  # noqa: E731
+        mul3 = lambda a: a * 3  # noqa: E731
+        concat_right = lambda a: a + "!"  # noqa: E731
+        concat_left = lambda a: "pre-" + a  # noqa: E731
+        repeat_lit = lambda x: "ab" * x  # noqa: E731
+        # (func, return_type, schema, rows, expected); arg columns come from schema.
+        cases = [
+            (add, S, "a string, b string", [("x", "y"), ("a", "b")], ["xy", "ab"]),
+            (mul, S, "a string, b long", [("ab", 3)], ["ababab"]),
+            (mul, S, "a long, b string", [(3, "ab")], ["ababab"]),
+            (mul3, S, "a string", [("2",), ("ab",)], ["222", "ababab"]),
+            (concat_right, S, "a string", [("hi",)], ["hi!"]),
+            (concat_left, S, "a string", [("x",)], ["pre-x"]),
+            (repeat_lit, S, "a long", [(3,)], ["ababab"]),
+        ]
+        for i, (func, rt, schema, rows, expected) in enumerate(cases):
+            with self.subTest(case=i):
+                self.assertEqual(self._vals(func, rt, schema, rows), expected, f"case {i}")
+
+    def test_udf_transpile_string_operands_fall_back(self):
+        # Operand/type combos with no valid string lowering for the bound column
+        # types fall back to the Python UDF, which raises the same way CPython does:
+        # `str + int` (and reversed), `str - int`, `str * str`, `str % int`, and a
+        # string column plus a numeric literal. The transpiler still emits numeric
+        # (and/or concat/repeat) variants, but none match the column types, so the
+        # JVM drops them and runs Python -- matching its TypeError.
         add = lambda a, b: a + b  # noqa: E731
         sub = lambda a, b: a - b  # noqa: E731
         mul = lambda a, b: a * b  # noqa: E731
         mod = lambda a, b: a % b  # noqa: E731
         add5 = lambda a: a + 5  # noqa: E731
-        mul3 = lambda a: a * 3  # noqa: E731
-        self._raises(add, "a string, b long", [("10", 5)])  # str + int
-        self._raises(add, "a long, b string", [(5, "10")])  # int + str
-        self._raises(add, "a string, b string", [("x", "y")])  # str + str
-        self._raises(sub, "a string, b long", [("10", 5)])
-        self._raises(mul, "a string, b long", [("2", 3)])
-        self._raises(mul, "a long, b string", [(3, "2")])  # int * str
-        self._raises(mod, "a string, b long", [("10", 3)])
-        self._raises(add5, "a string", [("10",)])  # str column + numeric literal
-        self._raises(mul3, "a string", [("2",)])
+        # needle="" -> assert only that it raises (the message is CPython's).
+        for func, schema, rows in [
+            (add, "a string, b long", [("10", 5)]),  # str + int
+            (add, "a long, b string", [(5, "10")]),  # int + str
+            (sub, "a string, b long", [("10", 5)]),  # str - int
+            (mul, "a string, b string", [("a", "b")]),  # str * str
+            (mod, "a string, b long", [("10", 3)]),  # str % int
+            (add5, "a string", [("10",)]),  # str column + numeric literal
+        ]:
+            with self.subTest(func=func, schema=schema):
+                self._raises(func, schema, rows, needle="")
 
     def test_udf_transpile_power_precision_divergence(self):
         # `**` -> Spark pow (DOUBLE); beyond ~2**53 it loses precision where

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -878,19 +878,29 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         self.assertIn("a", message)
 
     # ------------------------------------------------------------------
-    # Edge cases (SPARK-55206 follow-up), table-driven. ``_run`` builds a UDF
-    # with transpilation on, runs it, and returns ``(did_it_transpile, values)``.
-    # Cases use assigned lambdas (which transpile) or ``def``s; ``subTest``
-    # labels keep failures identifiable. Plan-elision checks count
-    # ``EvalPython`` nodes, since an ordering compare's ``raise_error`` message
-    # literal contains "UDF" (so the "UDF" substring is unreliable).
+    # Edge cases (SPARK-55206 follow-up). Helpers build a UDF with
+    # transpilation on; `_vals` runs it and returns outputs (asserting it
+    # transpiled), `_raises` asserts it raises. Arg columns come from the
+    # schema. Operator cases are table-driven. Plan-elision checks count
+    # `EvalPython` nodes because an ordering compare's `raise_error` message
+    # contains "UDF" (so the "UDF" substring is unreliable).
     # ------------------------------------------------------------------
 
-    def _run(self, func, return_type, rows, schema, *cols):
+    def _vals(self, func, return_type, schema, rows):
         with self.sql_conf(_TRANSPILE_ON):
             u = UserDefinedFunction(func, return_type)
+            self.assertTrue(u.transpiled, str(func))
             df = self.spark.createDataFrame(rows, schema)
-            return bool(u.transpiled), [r[0] for r in df.select(u(*cols)).collect()]
+            return [r[0] for r in df.select(u(*df.columns)).collect()]
+
+    def _raises(self, func, schema, rows, needle="numeric"):
+        with self.sql_conf(_TRANSPILE_ON):
+            u = UserDefinedFunction(func, LongType())
+            self.assertTrue(u.transpiled, str(func))
+            df = self.spark.createDataFrame(rows, schema)
+            with self.assertRaises(Exception) as ctx:
+                df.select(u(*df.columns)).collect()
+            self.assertIn(needle, str(ctx.exception).lower(), str(func))
 
     @staticmethod
     def _eval_python_count(df):
@@ -901,7 +911,6 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         # non-commutative -/* (parameter order), **, unary nesting, constant
         # body, not(compare), nested boolean, string ==/<, reversed-operand and
         # column-to-column comparisons, if/elif/else, and assigned lambdas.
-        # (Deterministic; the hypothesis suite that fuzzes these is gated.)
         L, B = LongType(), BooleanType()
         modulo = lambda x, y: x % y  # noqa: E731
         subtract = lambda a, b: a - b  # noqa: E731
@@ -917,7 +926,7 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         rev_lt = lambda x: (0 < x) if x is not None else None  # noqa: E731
         rev_eq = lambda x: 5 == x  # noqa: E731
         none_eq = lambda x: None == x  # noqa: E711,E731
-        col_lt = lambda a, b: (a < b) if (a is not None and b is not None) else None  # noqa: E731
+        col_lt = lambda a, b: (a < b) if a is not None and b is not None else None  # noqa: E731
         assigned = lambda v: v + 1  # noqa: E731
 
         def if_elif_else(x):
@@ -928,121 +937,45 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             else:
                 return 1
 
+        # (func, return_type, schema, rows, expected); arg columns come from the schema.
         cases = [
+            (modulo, L, "a long, b long", [(7, 3), (7, -3), (-7, 3), (-7, -3)], [1, -2, 2, -1]),
+            (subtract, L, "a long, b long", [(5, 3), (3, 5)], [2, -2]),
+            (multiply, L, "a long, b long", [(4, 3), (-2, 5)], [12, -10]),
+            (power, L, "a long", [(6,), (-3,), (0,)], [36, 9, 0]),
+            (double_neg, L, "a long", [(5,), (-3,)], [5, -3]),
+            (unary_pm, L, "a long", [(5,), (-3,)], [-5, 3]),
+            (constant, L, "a long", [(1,), (999,)], [42, 42]),
+            (not_pos, B, "a long", [(1,), (0,), (-1,), (None,)], [False, True, True, None]),
+            (str_eq, B, "a string", [("foo",), ("bar",), (None,)], [True, False, None]),
+            (str_lt, B, "a string", [("a",), ("z",), (None,)], [True, False, None]),
+            (rev_lt, B, "a long", [(1,), (0,), (-1,)], [True, False, False]),
+            (rev_eq, B, "a long", [(5,), (3,), (None,)], [True, False, False]),
+            (none_eq, B, "a long", [(None,), (5,)], [True, False]),
+            (col_lt, B, "a long, b long", [(1, 2), (2, 1), (1, 1)], [True, False, False]),
+            (if_elif_else, L, "a long", [(None,), (0,), (5,), (-3,)], [-1, 0, 1, 1]),
+            (assigned, L, "a long", [(1,), (10,)], [2, 11]),
             (
-                "modulo_sign",
-                modulo,
-                L,
-                [(7, 3), (7, -3), (-7, 3), (-7, -3), (0, 3), (5, -5)],
-                "a long, b long",
-                ("a", "b"),
-                [1, -2, 2, -1, 0, 0],
-            ),
-            (
-                "subtract_order",
-                subtract,
-                L,
-                [(5, 3), (3, 5)],
-                "a long, b long",
-                ("a", "b"),
-                [2, -2],
-            ),
-            ("multiply", multiply, L, [(4, 3), (-2, 5)], "a long, b long", ("a", "b"), [12, -10]),
-            ("power", power, L, [(6,), (-3,), (0,)], "a long", ("a",), [36, 9, 0]),
-            ("double_negate", double_neg, L, [(5,), (-3,)], "a long", ("a",), [5, -3]),
-            ("unary_plus_minus", unary_pm, L, [(5,), (-3,)], "a long", ("a",), [-5, 3]),
-            ("constant_body", constant, L, [(1,), (999,)], "a long", ("a",), [42, 42]),
-            (
-                "not_comparison",
-                not_pos,
-                B,
-                [(1,), (0,), (-1,), (None,)],
-                "a long",
-                ("a",),
-                [False, True, True, None],
-            ),
-            (
-                "nested_boolean",
                 nested,
                 B,
-                [(1, 1, 5), (-1, 1, 0), (-1, 1, 5), (1, -1, 9)],
                 "a long, b long, c long",
-                ("a", "b", "c"),
-                [True, True, False, False],
+                [(1, 1, 5), (-1, 1, 0), (-1, 1, 5)],
+                [True, True, False],
             ),
-            (
-                "string_equality",
-                str_eq,
-                B,
-                [("foo",), ("bar",), (None,)],
-                "a string",
-                ("a",),
-                [True, False, None],
-            ),
-            (
-                "string_ordering",
-                str_lt,
-                B,
-                [("a",), ("z",), (None,)],
-                "a string",
-                ("a",),
-                [True, False, None],
-            ),
-            (
-                "reversed_less_than",
-                rev_lt,
-                B,
-                [(1,), (0,), (-1,)],
-                "a long",
-                ("a",),
-                [True, False, False],
-            ),
-            (
-                "reversed_equals",
-                rev_eq,
-                B,
-                [(5,), (3,), (None,)],
-                "a long",
-                ("a",),
-                [True, False, False],
-            ),
-            ("none_equals_col", none_eq, B, [(None,), (5,)], "a long", ("a",), [True, False]),
-            (
-                "column_lt_column",
-                col_lt,
-                B,
-                [(1, 2), (2, 1), (1, 1)],
-                "a long, b long",
-                ("a", "b"),
-                [True, False, False],
-            ),
-            (
-                "if_elif_else",
-                if_elif_else,
-                L,
-                [(None,), (0,), (5,), (-3,)],
-                "a long",
-                ("a",),
-                [-1, 0, 1, 1],
-            ),
-            ("assigned_lambda", assigned, L, [(1,), (10,)], "a long", ("a",), [2, 11]),
         ]
-        for label, func, rt, rows, schema, cols, expected in cases:
-            with self.subTest(label):
-                transpiled, values = self._run(func, rt, rows, schema, *cols)
-                self.assertTrue(transpiled, f"{label}: should transpile")
-                self.assertEqual(values, expected, label)
+        for i, (func, rt, schema, rows, expected) in enumerate(cases):
+            with self.subTest(case=i):
+                self.assertEqual(self._vals(func, rt, schema, rows), expected, f"case {i}: {rows}")
 
     def test_udf_transpile_callable_object_self_offset(self):
-        # A callable instance carries ``self``; the extractor offsets it so a/b
+        # A callable instance carries `self`; the extractor offsets it so a/b
         # map to _udf_param_0/_udf_param_1 (non-commutative body proves order).
         class SubAB:
             def __call__(self, a, b):
                 return a - b
 
         self.assertEqual(
-            self._run(SubAB(), LongType(), [(5, 3), (3, 5)], "a long, b long", "a", "b"),
-            (True, [2, -2]),
+            self._vals(SubAB(), LongType(), "a long, b long", [(5, 3), (3, 5)]), [2, -2]
         )
 
     def test_udf_transpile_plan_elision(self):
@@ -1098,12 +1031,12 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             col = self.spark.createDataFrame([(1,)], "a long").select(d("a").alias("r"))
             self.assertEqual(col.schema["r"].dataType, DoubleType())
             self.assertEqual(col.first()[0], 2.0)
-        self.assertEqual(self._run(plus_one, LongType(), [(1,)], "a long", "a"), (True, [2]))
+        self.assertEqual(self._vals(plus_one, LongType(), "a long", [(1,)]), [2])
 
     def test_udf_transpile_falls_back(self):
         # Shapes that must NOT transpile (and still compute via Python):
-        # inline/wrapped/partial lambdas, default/variadic/keyword-only args,
-        # and string-literal operator overloading (+, %, * over text).
+        # inline/wrapped/partial lambdas, default/variadic/keyword-only args, and
+        # string-literal operator overloading (+, %, * over text).
         import functools
 
         def wrapper(fn):
@@ -1132,17 +1065,18 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self.assertEqual(
                 [], UserDefinedFunction(functools.partial(base, 1), LongType()).transpiled
             )
-            for label, func, rt in [
-                ("default_arg", with_default, LongType()),
-                ("varargs", with_varargs, LongType()),
-                ("kwargs", with_kwargs, LongType()),
-                ("concat_right", concat_right, StringType()),
-                ("concat_left", concat_left, StringType()),
-                ("percent_format", percent_fmt, StringType()),
-                ("repeat", repeat, StringType()),
+            # default / variadic / keyword-only args, and string-literal +/%/* over text
+            for func, rt in [
+                (with_default, LongType()),
+                (with_varargs, LongType()),
+                (with_kwargs, LongType()),
+                (concat_right, StringType()),
+                (concat_left, StringType()),
+                (percent_fmt, StringType()),
+                (repeat, StringType()),
             ]:
-                with self.subTest(label):
-                    self.assertEqual([], UserDefinedFunction(func, rt).transpiled, label)
+                with self.subTest(func=func):
+                    self.assertEqual([], UserDefinedFunction(func, rt).transpiled)
             # Fell back -> interpreted Python still computes correctly.
             sdf = self.spark.createDataFrame([("hi",)], "a string")
             self.assertEqual(
@@ -1155,105 +1089,59 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             )
 
     def test_udf_transpile_known_value_divergences(self):
-        # Transpile but DIVERGE from Python (need runtime value info to fix;
-        # documented in transpile.py). Pinned so a future fix is noticed:
-        # unguarded arithmetic on NULL yields NULL (Python raises TypeError),
-        # NaN > 0 is True (Python False; Spark orders NaN highest), and a
-        # comparison to a cross-type literal coerces (int == "5" -> True; Python
-        # False). Mixed str/numeric *arithmetic* now raises instead -- see the
-        # pathological-operands test below.
+        # Transpile but DIVERGE from Python (documented in transpile.py; pinned so
+        # a future fix is noticed): unguarded arithmetic on NULL yields NULL
+        # (Python raises TypeError), NaN > 0 is True (Python False; Spark orders
+        # NaN highest), and comparing to a cross-type literal coerces (int == "5"
+        # -> True; Python False). Mixed str/numeric arithmetic raises -- see below.
         unguarded = lambda x: x + 1  # noqa: E731
         nan_gt = lambda x: (x > 0) if x is not None else None  # noqa: E731
         eq_strlit = lambda x: (x == "5") if x is not None else None  # noqa: E731
-        cases = [
-            ("unguarded_null", unguarded, LongType(), [(None,), (5,)], "a long", ("a",), [None, 6]),
-            (
-                "nan_gt_zero",
-                nan_gt,
-                BooleanType(),
-                [(float("nan"),), (1.0,)],
-                "a double",
-                ("a",),
-                [True, True],
-            ),
-            (
-                "int_eq_strlit",
-                eq_strlit,
-                BooleanType(),
-                [(5,), (3,)],
-                "a long",
-                ("a",),
-                [True, False],
-            ),
-        ]
-        for label, func, rt, rows, schema, cols, expected in cases:
-            with self.subTest(label):
-                transpiled, values = self._run(func, rt, rows, schema, *cols)
-                self.assertTrue(transpiled, label)
-                self.assertEqual(values, expected, label)
+        self.assertEqual(self._vals(unguarded, LongType(), "a long", [(None,), (5,)]), [None, 6])
+        self.assertEqual(
+            self._vals(nan_gt, BooleanType(), "a double", [(float("nan"),), (1.0,)]), [True, True]
+        )
+        self.assertEqual(
+            self._vals(eq_strlit, BooleanType(), "a long", [(5,), (3,)]), [True, False]
+        )
 
     def test_udf_transpile_known_raise_divergences(self):
         # Transpile but raise where Python differs: overflow under ANSI vs
-        # Python's big int (SPARK-55210), and ``% 0`` (both raise, compatible).
+        # Python's big int (SPARK-55210), and `% 0` (both raise, compatible).
         overflow = lambda x: x * x  # noqa: E731
         modulo_zero = lambda x: x % 0  # noqa: E731
-        cases = [
-            ("overflow", overflow, LongType(), [(4000000000,)], "a long", ("a",), "OVERFLOW"),
-            ("modulo_by_zero", modulo_zero, LongType(), [(5,)], "a long", ("a",), "ZERO"),
-        ]
-        for label, func, rt, rows, schema, cols, needle in cases:
-            with self.subTest(label):
-                with self.sql_conf(_TRANSPILE_ON):
-                    u = UserDefinedFunction(func, rt)
-                    self.assertTrue(u.transpiled, label)
-                    df = self.spark.createDataFrame(rows, schema)
-                    with self.assertRaises(Exception) as ctx:
-                        df.select(u(*cols)).collect()
-                    self.assertIn(needle, str(ctx.exception).upper(), label)
+        self._raises(overflow, "a long", [(4000000000,)], "overflow")
+        self._raises(modulo_zero, "a long", [(5,)], "zero")
 
     def test_udf_transpile_mixed_string_numeric_operands_raise(self):
         # The transpiler can't see column types, so for any non-constant operand
-        # it emits a runtime numeric-type guard: a string/binary column in
-        # arithmetic raises loudly instead of Spark silently coercing it (the
-        # literal guard alone can't catch a string passed as a *column*). These
-        # pathological str/numeric mixes -- including str and int passed as
-        # separate UDF params -- must raise, not miscompute. Python would
-        # concatenate, repeat, format, or raise TypeError; we fail loudly.
+        # it emits a runtime numeric guard: a string/binary column in arithmetic
+        # raises loudly rather than let Spark silently coerce it (the literal
+        # guard alone can't catch a string passed as a *column*). These str/numeric
+        # mixes -- str and int as separate UDF params included -- must raise, not
+        # miscompute (Python would concatenate, repeat, format, or raise TypeError).
         add = lambda a, b: a + b  # noqa: E731
         sub = lambda a, b: a - b  # noqa: E731
         mul = lambda a, b: a * b  # noqa: E731
         mod = lambda a, b: a % b  # noqa: E731
         add5 = lambda a: a + 5  # noqa: E731
         mul3 = lambda a: a * 3  # noqa: E731
-        cases = [
-            ("str_col+int_col", add, [("10", 5)], "a string, b long", ("a", "b")),
-            ("int_col+str_col", add, [(5, "10")], "a long, b string", ("a", "b")),
-            ("str_col+str_col", add, [("x", "y")], "a string, b string", ("a", "b")),
-            ("str_col-int_col", sub, [("10", 5)], "a string, b long", ("a", "b")),
-            ("str_col*int_col", mul, [("2", 3)], "a string, b long", ("a", "b")),
-            ("int_col*str_col", mul, [(3, "2")], "a long, b string", ("a", "b")),
-            ("str_col%int_col", mod, [("10", 3)], "a string, b long", ("a", "b")),
-            ("str_col+int_literal", add5, [("10",)], "a string", ("a",)),
-            ("str_col*int_literal", mul3, [("2",)], "a string", ("a",)),
-        ]
-        for label, func, rows, schema, cols in cases:
-            with self.subTest(label):
-                with self.sql_conf(_TRANSPILE_ON):
-                    u = UserDefinedFunction(func, LongType())
-                    self.assertTrue(u.transpiled, label)
-                    df = self.spark.createDataFrame(rows, schema)
-                    with self.assertRaises(Exception) as ctx:
-                        df.select(u(*cols)).collect()
-                    self.assertIn("numeric", str(ctx.exception).lower(), label)
+        self._raises(add, "a string, b long", [("10", 5)])  # str + int
+        self._raises(add, "a long, b string", [(5, "10")])  # int + str
+        self._raises(add, "a string, b string", [("x", "y")])  # str + str
+        self._raises(sub, "a string, b long", [("10", 5)])
+        self._raises(mul, "a string, b long", [("2", 3)])
+        self._raises(mul, "a long, b string", [(3, "2")])  # int * str
+        self._raises(mod, "a string, b long", [("10", 3)])
+        self._raises(add5, "a string", [("10",)])  # str column + numeric literal
+        self._raises(mul3, "a string", [("2",)])
 
     def test_udf_transpile_power_precision_divergence(self):
         # `**` -> Spark pow (DOUBLE); beyond ~2**53 it loses precision where
         # Python keeps exact ints. Documented limitation.
         square = lambda x: x**2  # noqa: E731
         x = 134217729  # 2**27 + 1; exact square exceeds double's 2**53 range
-        self.assertEqual(
-            self._run(square, LongType(), [(x,)], "a long", "a"), (True, [18014398777917440])
-        )
+        self.assertEqual(self._vals(square, LongType(), "a long", [(x,)]), [18014398777917440])
         self.assertNotEqual(x * x, 18014398777917440)  # Python's exact value differs
 
 

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -1337,12 +1337,13 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self.assertEqual(idf.select(pf("a")).first()[0], "n=5")
             self.assertEqual(idf.select(rp("a")).first()[0], "ababababab")  # "ab" * 5
 
-    def test_udf_transpile_string_column_arithmetic_known_divergence(self):
-        # KNOWN LIMITATION: a string *column* combined with a number can't be
-        # detected statically, so it transpiles and diverges from Python --
-        # Spark coerces the string to a number, while Python would concatenate,
-        # repeat, or raise. Pinned so schema-aware handling (if it ever lands)
-        # trips this test.
+    def test_udf_transpile_string_column_arithmetic(self):
+        # A string *column* combined with a number can't be detected at
+        # transpile time (no schema info). For `+` this stays a documented
+        # divergence: Spark coerces "10" + 5 -> 15 where Python raises
+        # TypeError. For `*` the transpiler now guards at runtime so a string
+        # operand raises loudly instead of silently miscomputing ("2" * 3 used
+        # to yield 6, not Python's "222").
         def col_plus_5(a):
             if a is not None:
                 return a + 5
@@ -1354,16 +1355,36 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         with self.sql_conf(_TRANSPILE_ON):
             plus_udf = UserDefinedFunction(col_plus_5, LongType())
             times_udf = UserDefinedFunction(col_times_3, StringType())
-            self.assertTrue(
-                plus_udf.transpiled and times_udf.transpiled,
-                "string-column arithmetic still transpiles today (no schema info)",
-            )
-            # "10" + 5 -> Spark coerces to 15; interpreted Python raises TypeError.
+            self.assertTrue(plus_udf.transpiled and times_udf.transpiled)
+            # `+`: KNOWN DIVERGENCE -- Spark coerces "10" + 5 to 15; Python raises.
             num_df = self.spark.createDataFrame([("10",)], "a string")
             self.assertEqual(num_df.select(plus_udf("a")).first()[0], 15)
-            # "2" * 3 -> Spark coerces to "6"; interpreted Python gives "222".
-            two_df = self.spark.createDataFrame([("2",)], "a string")
-            self.assertEqual(two_df.select(times_udf("a")).first()[0], "6")
+            # `*`: a string operand now raises rather than silently coercing
+            # (both a numeric-looking "2" and a non-numeric "ab").
+            for val in ["2", "ab"]:
+                with self.subTest(times_value=val):
+                    sdf = self.spark.createDataFrame([(val,)], "a string")
+                    with self.assertRaises(Exception) as ctx:
+                        sdf.select(times_udf("a")).collect()
+                    self.assertIn("numeric", str(ctx.exception).lower())
+
+    def test_udf_transpile_power_precision_known_divergence(self):
+        # KNOWN DIVERGENCE: `**` lowers to Spark `pow`, which returns DOUBLE, so
+        # beyond ~2**53 the exact integer can't be represented and the
+        # transpiled result is off by rounding where Python keeps the exact int.
+        # Values within the safe range still match (see the param-order test);
+        # this pins the boundary behavior as a documented limitation.
+        def square(x):
+            if x is not None:
+                return x ** 2
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(square, LongType())
+            self.assertTrue(pudf.transpiled)
+            x = 134217729  # 2**27 + 1; exact square exceeds double's 2**53 range
+            df = self.spark.createDataFrame([(x,)], "a long")
+            self.assertEqual(df.select(pudf("a")).first()[0], 18014398777917440)
+            self.assertNotEqual(x * x, 18014398777917440)  # Python's exact value differs
 
     def test_udf_transpile_unguarded_arithmetic_on_null_known_divergence(self):
         # KNOWN DIVERGENCE: arithmetic is not null-guarded (unlike the ordering

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -906,8 +906,8 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         modulo = lambda x, y: x % y  # noqa: E731
         subtract = lambda a, b: a - b  # noqa: E731
         multiply = lambda a, b: a * b  # noqa: E731
-        power = lambda x: x ** 2  # noqa: E731
-        double_neg = lambda x: - -x  # noqa: E731
+        power = lambda x: x**2  # noqa: E731
+        double_neg = lambda x: --x  # noqa: E731
         unary_pm = lambda x: +(-x)  # noqa: E731
         constant = lambda x: 42  # noqa: E731
         not_pos = lambda x: (not (x > 0)) if x is not None else None  # noqa: E731
@@ -929,31 +929,102 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
                 return 1
 
         cases = [
-            ("modulo_sign", modulo, L, [(7, 3), (7, -3), (-7, 3), (-7, -3), (0, 3), (5, -5)],
-             "a long, b long", ("a", "b"), [1, -2, 2, -1, 0, 0]),
-            ("subtract_order", subtract, L, [(5, 3), (3, 5)], "a long, b long", ("a", "b"), [2, -2]),
+            (
+                "modulo_sign",
+                modulo,
+                L,
+                [(7, 3), (7, -3), (-7, 3), (-7, -3), (0, 3), (5, -5)],
+                "a long, b long",
+                ("a", "b"),
+                [1, -2, 2, -1, 0, 0],
+            ),
+            (
+                "subtract_order",
+                subtract,
+                L,
+                [(5, 3), (3, 5)],
+                "a long, b long",
+                ("a", "b"),
+                [2, -2],
+            ),
             ("multiply", multiply, L, [(4, 3), (-2, 5)], "a long, b long", ("a", "b"), [12, -10]),
             ("power", power, L, [(6,), (-3,), (0,)], "a long", ("a",), [36, 9, 0]),
             ("double_negate", double_neg, L, [(5,), (-3,)], "a long", ("a",), [5, -3]),
             ("unary_plus_minus", unary_pm, L, [(5,), (-3,)], "a long", ("a",), [-5, 3]),
             ("constant_body", constant, L, [(1,), (999,)], "a long", ("a",), [42, 42]),
-            ("not_comparison", not_pos, B, [(1,), (0,), (-1,), (None,)], "a long", ("a",),
-             [False, True, True, None]),
-            ("nested_boolean", nested, B, [(1, 1, 5), (-1, 1, 0), (-1, 1, 5), (1, -1, 9)],
-             "a long, b long, c long", ("a", "b", "c"), [True, True, False, False]),
-            ("string_equality", str_eq, B, [("foo",), ("bar",), (None,)], "a string", ("a",),
-             [True, False, None]),
-            ("string_ordering", str_lt, B, [("a",), ("z",), (None,)], "a string", ("a",),
-             [True, False, None]),
-            ("reversed_less_than", rev_lt, B, [(1,), (0,), (-1,)], "a long", ("a",),
-             [True, False, False]),
-            ("reversed_equals", rev_eq, B, [(5,), (3,), (None,)], "a long", ("a",),
-             [True, False, False]),
+            (
+                "not_comparison",
+                not_pos,
+                B,
+                [(1,), (0,), (-1,), (None,)],
+                "a long",
+                ("a",),
+                [False, True, True, None],
+            ),
+            (
+                "nested_boolean",
+                nested,
+                B,
+                [(1, 1, 5), (-1, 1, 0), (-1, 1, 5), (1, -1, 9)],
+                "a long, b long, c long",
+                ("a", "b", "c"),
+                [True, True, False, False],
+            ),
+            (
+                "string_equality",
+                str_eq,
+                B,
+                [("foo",), ("bar",), (None,)],
+                "a string",
+                ("a",),
+                [True, False, None],
+            ),
+            (
+                "string_ordering",
+                str_lt,
+                B,
+                [("a",), ("z",), (None,)],
+                "a string",
+                ("a",),
+                [True, False, None],
+            ),
+            (
+                "reversed_less_than",
+                rev_lt,
+                B,
+                [(1,), (0,), (-1,)],
+                "a long",
+                ("a",),
+                [True, False, False],
+            ),
+            (
+                "reversed_equals",
+                rev_eq,
+                B,
+                [(5,), (3,), (None,)],
+                "a long",
+                ("a",),
+                [True, False, False],
+            ),
             ("none_equals_col", none_eq, B, [(None,), (5,)], "a long", ("a",), [True, False]),
-            ("column_lt_column", col_lt, B, [(1, 2), (2, 1), (1, 1)], "a long, b long", ("a", "b"),
-             [True, False, False]),
-            ("if_elif_else", if_elif_else, L, [(None,), (0,), (5,), (-3,)], "a long", ("a",),
-             [-1, 0, 1, 1]),
+            (
+                "column_lt_column",
+                col_lt,
+                B,
+                [(1, 2), (2, 1), (1, 1)],
+                "a long, b long",
+                ("a", "b"),
+                [True, False, False],
+            ),
+            (
+                "if_elif_else",
+                if_elif_else,
+                L,
+                [(None,), (0,), (5,), (-3,)],
+                "a long",
+                ("a",),
+                [-1, 0, 1, 1],
+            ),
             ("assigned_lambda", assigned, L, [(1,), (10,)], "a long", ("a",), [2, 11]),
         ]
         for label, func, rt, rows, schema, cols, expected in cases:
@@ -1055,8 +1126,12 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         with self.sql_conf(_TRANSPILE_ON):
             # inline / wrapped / partial lambdas -> source can't be extracted
             self.assertEqual([], UserDefinedFunction(lambda v: v + 1, LongType()).transpiled)
-            self.assertEqual([], UserDefinedFunction(wrapper(lambda v: v + 1), LongType()).transpiled)
-            self.assertEqual([], UserDefinedFunction(functools.partial(base, 1), LongType()).transpiled)
+            self.assertEqual(
+                [], UserDefinedFunction(wrapper(lambda v: v + 1), LongType()).transpiled
+            )
+            self.assertEqual(
+                [], UserDefinedFunction(functools.partial(base, 1), LongType()).transpiled
+            )
             for label, func, rt in [
                 ("default_arg", with_default, LongType()),
                 ("varargs", with_varargs, LongType()),
@@ -1080,23 +1155,36 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             )
 
     def test_udf_transpile_known_value_divergences(self):
-        # Transpile but DIVERGE from Python (need runtime type/value info to
-        # fix; documented in transpile.py). Pinned so a future fix is noticed:
-        # unguarded arithmetic on NULL yields NULL (Python raises TypeError);
-        # NaN > 0 is True (Python False; Spark orders NaN highest); int == "5"
-        # coerces to True (Python False); string-column + number coerces
-        # ("10" + 5 -> 15; Python raises).
+        # Transpile but DIVERGE from Python (need runtime value info to fix;
+        # documented in transpile.py). Pinned so a future fix is noticed:
+        # unguarded arithmetic on NULL yields NULL (Python raises TypeError),
+        # NaN > 0 is True (Python False; Spark orders NaN highest), and a
+        # comparison to a cross-type literal coerces (int == "5" -> True; Python
+        # False). Mixed str/numeric *arithmetic* now raises instead -- see the
+        # pathological-operands test below.
         unguarded = lambda x: x + 1  # noqa: E731
         nan_gt = lambda x: (x > 0) if x is not None else None  # noqa: E731
         eq_strlit = lambda x: (x == "5") if x is not None else None  # noqa: E731
-        strcol_plus = lambda a: (a + 5) if a is not None else None  # noqa: E731
         cases = [
             ("unguarded_null", unguarded, LongType(), [(None,), (5,)], "a long", ("a",), [None, 6]),
-            ("nan_gt_zero", nan_gt, BooleanType(), [(float("nan"),), (1.0,)], "a double", ("a",),
-             [True, True]),
-            ("int_eq_strlit", eq_strlit, BooleanType(), [(5,), (3,)], "a long", ("a",),
-             [True, False]),
-            ("strcol_plus_num", strcol_plus, LongType(), [("10",)], "a string", ("a",), [15]),
+            (
+                "nan_gt_zero",
+                nan_gt,
+                BooleanType(),
+                [(float("nan"),), (1.0,)],
+                "a double",
+                ("a",),
+                [True, True],
+            ),
+            (
+                "int_eq_strlit",
+                eq_strlit,
+                BooleanType(),
+                [(5,), (3,)],
+                "a long",
+                ("a",),
+                [True, False],
+            ),
         ]
         for label, func, rt, rows, schema, cols, expected in cases:
             with self.subTest(label):
@@ -1106,19 +1194,12 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
 
     def test_udf_transpile_known_raise_divergences(self):
         # Transpile but raise where Python differs: overflow under ANSI vs
-        # Python bigint (SPARK-55210); ``% 0`` (both raise); and string-column
-        # ``*`` is type-guarded to raise rather than silently coerce
-        # ("2" * 3 -> 6 instead of Python's "222").
+        # Python's big int (SPARK-55210), and ``% 0`` (both raise, compatible).
         overflow = lambda x: x * x  # noqa: E731
         modulo_zero = lambda x: x % 0  # noqa: E731
-        strcol_times = lambda a: a * 3  # noqa: E731
         cases = [
             ("overflow", overflow, LongType(), [(4000000000,)], "a long", ("a",), "OVERFLOW"),
             ("modulo_by_zero", modulo_zero, LongType(), [(5,)], "a long", ("a",), "ZERO"),
-            ("strcol_times_numeric", strcol_times, StringType(), [("2",)], "a string", ("a",),
-             "NUMERIC"),
-            ("strcol_times_text", strcol_times, StringType(), [("ab",)], "a string", ("a",),
-             "NUMERIC"),
         ]
         for label, func, rt, rows, schema, cols, needle in cases:
             with self.subTest(label):
@@ -1130,10 +1211,45 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
                         df.select(u(*cols)).collect()
                     self.assertIn(needle, str(ctx.exception).upper(), label)
 
+    def test_udf_transpile_mixed_string_numeric_operands_raise(self):
+        # The transpiler can't see column types, so for any non-constant operand
+        # it emits a runtime numeric-type guard: a string/binary column in
+        # arithmetic raises loudly instead of Spark silently coercing it (the
+        # literal guard alone can't catch a string passed as a *column*). These
+        # pathological str/numeric mixes -- including str and int passed as
+        # separate UDF params -- must raise, not miscompute. Python would
+        # concatenate, repeat, format, or raise TypeError; we fail loudly.
+        add = lambda a, b: a + b  # noqa: E731
+        sub = lambda a, b: a - b  # noqa: E731
+        mul = lambda a, b: a * b  # noqa: E731
+        mod = lambda a, b: a % b  # noqa: E731
+        add5 = lambda a: a + 5  # noqa: E731
+        mul3 = lambda a: a * 3  # noqa: E731
+        cases = [
+            ("str_col+int_col", add, [("10", 5)], "a string, b long", ("a", "b")),
+            ("int_col+str_col", add, [(5, "10")], "a long, b string", ("a", "b")),
+            ("str_col+str_col", add, [("x", "y")], "a string, b string", ("a", "b")),
+            ("str_col-int_col", sub, [("10", 5)], "a string, b long", ("a", "b")),
+            ("str_col*int_col", mul, [("2", 3)], "a string, b long", ("a", "b")),
+            ("int_col*str_col", mul, [(3, "2")], "a long, b string", ("a", "b")),
+            ("str_col%int_col", mod, [("10", 3)], "a string, b long", ("a", "b")),
+            ("str_col+int_literal", add5, [("10",)], "a string", ("a",)),
+            ("str_col*int_literal", mul3, [("2",)], "a string", ("a",)),
+        ]
+        for label, func, rows, schema, cols in cases:
+            with self.subTest(label):
+                with self.sql_conf(_TRANSPILE_ON):
+                    u = UserDefinedFunction(func, LongType())
+                    self.assertTrue(u.transpiled, label)
+                    df = self.spark.createDataFrame(rows, schema)
+                    with self.assertRaises(Exception) as ctx:
+                        df.select(u(*cols)).collect()
+                    self.assertIn("numeric", str(ctx.exception).lower(), label)
+
     def test_udf_transpile_power_precision_divergence(self):
         # `**` -> Spark pow (DOUBLE); beyond ~2**53 it loses precision where
         # Python keeps exact ints. Documented limitation.
-        square = lambda x: x ** 2  # noqa: E731
+        square = lambda x: x**2  # noqa: E731
         x = 134217729  # 2**27 + 1; exact square exceeds double's 2**53 range
         self.assertEqual(
             self._run(square, LongType(), [(x,)], "a long", "a"), (True, [18014398777917440])

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -878,191 +878,49 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         self.assertIn("a", message)
 
     # ------------------------------------------------------------------
-    # Edge cases (SPARK-55206 follow-up). Behaviors below were confirmed
-    # against the running transpiler; fallbacks are locked in as the safe
-    # contract. Note: ordering comparisons emit a ``raise_error`` whose
-    # message literal contains "UDF", so plan-elision checks count
-    # ``EvalPython`` nodes rather than the "UDF" substring.
+    # Edge cases (SPARK-55206 follow-up), table-driven. ``_run`` builds a UDF
+    # with transpilation on, runs it, and returns ``(did_it_transpile, values)``.
+    # Cases use assigned lambdas (which transpile) or ``def``s; ``subTest``
+    # labels keep failures identifiable. Plan-elision checks count
+    # ``EvalPython`` nodes, since an ordering compare's ``raise_error`` message
+    # literal contains "UDF" (so the "UDF" substring is unreliable).
     # ------------------------------------------------------------------
+
+    def _run(self, func, return_type, rows, schema, *cols):
+        with self.sql_conf(_TRANSPILE_ON):
+            u = UserDefinedFunction(func, return_type)
+            df = self.spark.createDataFrame(rows, schema)
+            return bool(u.transpiled), [r[0] for r in df.select(u(*cols)).collect()]
 
     @staticmethod
     def _eval_python_count(df):
-        plan = df._jdf.queryExecution().executedPlan().toString()
-        return plan.count("EvalPython")
+        return df._jdf.queryExecution().executedPlan().toString().count("EvalPython")
 
-    def test_udf_transpile_modulo_sign_parity(self):
-        # Python's ``%`` takes the sign of the divisor; Spark's ``%`` takes
-        # the sign of the dividend. The transpiler rewrites ``a % b`` as
-        # ``sign(b) * pmod(sign(b) * a, abs(b))`` so the result matches
-        # Python for negative operands. Pin that parity deterministically
-        # (the hypothesis suite that fuzzes this is gated behind
-        # RUN_HYPOTHESIS and skips in normal runs).
-        def py_mod(x, y):
-            if x is not None and y is not None:
-                return x % y
+    def test_udf_transpile_lowers_operators(self):
+        # Operators lower to Catalyst and match Python: modulo sign-parity,
+        # non-commutative -/* (parameter order), **, unary nesting, constant
+        # body, not(compare), nested boolean, string ==/<, reversed-operand and
+        # column-to-column comparisons, if/elif/else, and assigned lambdas.
+        # (Deterministic; the hypothesis suite that fuzzes these is gated.)
+        L, B = LongType(), BooleanType()
+        modulo = lambda x, y: x % y  # noqa: E731
+        subtract = lambda a, b: a - b  # noqa: E731
+        multiply = lambda a, b: a * b  # noqa: E731
+        power = lambda x: x ** 2  # noqa: E731
+        double_neg = lambda x: - -x  # noqa: E731
+        unary_pm = lambda x: +(-x)  # noqa: E731
+        constant = lambda x: 42  # noqa: E731
+        not_pos = lambda x: (not (x > 0)) if x is not None else None  # noqa: E731
+        nested = lambda x, y, z: ((x > 0) and (y > 0)) or (z == 0)  # noqa: E731
+        str_eq = lambda x: (x == "foo") if x is not None else None  # noqa: E731
+        str_lt = lambda x: (x < "m") if x is not None else None  # noqa: E731
+        rev_lt = lambda x: (0 < x) if x is not None else None  # noqa: E731
+        rev_eq = lambda x: 5 == x  # noqa: E731
+        none_eq = lambda x: None == x  # noqa: E711,E731
+        col_lt = lambda a, b: (a < b) if (a is not None and b is not None) else None  # noqa: E731
+        assigned = lambda v: v + 1  # noqa: E731
 
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(py_mod, LongType())
-            self.assertTrue(pudf.transpiled, "two-arg modulo should transpile")
-            for a, b in [(7, 3), (7, -3), (-7, 3), (-7, -3), (0, 3), (5, -5), (-8, 3)]:
-                with self.subTest(a=a, b=b):
-                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
-                    self.assertEqual(
-                        df.select(pudf("a", "b")).first()[0],
-                        a % b,
-                        f"{a} % {b} should match Python semantics",
-                    )
-
-    def test_udf_transpile_binary_arithmetic_param_order(self):
-        # ``-``, ``*``, ``**`` lower to the matching Column ops. The two-arg
-        # non-commutative cases also prove parameter order is preserved
-        # (a -> _udf_param_0, b -> _udf_param_1), not swapped.
-        def sub_ab(a, b):
-            if a is not None and b is not None:
-                return a - b
-
-        def mul_ab(a, b):
-            if a is not None and b is not None:
-                return a * b
-
-        def square(x):
-            if x is not None:
-                return x ** 2
-
-        with self.sql_conf(_TRANSPILE_ON):
-            sub_udf = UserDefinedFunction(sub_ab, LongType())
-            mul_udf = UserDefinedFunction(mul_ab, LongType())
-            sq_udf = UserDefinedFunction(square, LongType())
-            self.assertTrue(sub_udf.transpiled and mul_udf.transpiled and sq_udf.transpiled)
-            for a, b, expected in [(5, 3, 2), (3, 5, -2), (0, 7, -7)]:
-                with self.subTest(op="sub", a=a, b=b):
-                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
-                    self.assertEqual(df.select(sub_udf("a", "b")).first()[0], expected)
-            for a, b, expected in [(4, 3, 12), (-2, 5, -10)]:
-                with self.subTest(op="mul", a=a, b=b):
-                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
-                    self.assertEqual(df.select(mul_udf("a", "b")).first()[0], expected)
-            for x, expected in [(6, 36), (-3, 9), (0, 0)]:
-                with self.subTest(op="pow", x=x):
-                    df = self.spark.createDataFrame([(x,)], "a long")
-                    self.assertEqual(df.select(sq_udf("a")).first()[0], expected)
-
-    def test_udf_transpile_assigned_lambda_transpiles(self):
-        # A lambda bound to a name parses as ``Assign(value=Lambda)``, which
-        # the extractor handles, so it transpiles.
-        adder = lambda v: v + 1  # noqa: E731
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(adder, LongType())
-            self.assertTrue(pudf.transpiled, "assigned lambda should transpile")
-            df = self.spark.createDataFrame([(1,), (10,)], "a long")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [2, 11])
-
-    def test_udf_transpile_inline_and_wrapped_lambda_fall_back(self):
-        # ``inspect.getsource`` on an inline or wrapped lambda returns the
-        # enclosing ``Assign(value=Call(...))``; the extractor has no
-        # ``ast.Call`` branch, so these fall back to interpreted Python (the
-        # docstring's "wrapped lambda" support is aspirational). Each must
-        # still compute the correct value.
-        import functools
-
-        def wrapper(fn):
-            return fn
-
-        with self.sql_conf(_TRANSPILE_ON):
-            inline = UserDefinedFunction(lambda v: v + 1, LongType())
-            self.assertEqual([], inline.transpiled, "inline lambda must fall back")
-
-            wrapped = UserDefinedFunction(wrapper(lambda v: v + 1), LongType())
-            self.assertEqual([], wrapped.transpiled, "wrapped lambda must fall back")
-
-            base = lambda v, w: v + w  # noqa: E731
-            partial = UserDefinedFunction(functools.partial(base, 1), LongType())
-            self.assertEqual([], partial.transpiled, "functools.partial must fall back")
-
-            df = self.spark.createDataFrame([(4,)], "a long")
-            self.assertEqual(df.select(inline("a")).first()[0], 5)
-            self.assertEqual(df.select(wrapped("a")).first()[0], 5)
-            self.assertEqual(df.select(partial("a")).first()[0], 5)
-
-    def test_udf_transpile_callable_object_multi_arg(self):
-        # A callable instance carries ``self`` as the first parameter; the
-        # extractor offsets it so ``a``/``b`` map to _udf_param_0/_udf_param_1.
-        # A non-commutative body proves both the offset and the order.
-        class SubAB:
-            def __call__(self, a, b):
-                if a is not None and b is not None:
-                    return a - b
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(SubAB(), LongType())
-            self.assertTrue(pudf.transpiled, "callable object should transpile")
-            for a, b, expected in [(5, 3, 2), (3, 5, -2)]:
-                with self.subTest(a=a, b=b):
-                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
-                    self.assertEqual(df.select(pudf("a", "b")).first()[0], expected)
-
-    def test_udf_transpile_not_of_comparison(self):
-        # ``not (x > 0)`` -- the operand is a Compare (statically boolean), so
-        # ``not`` lowers (the positive control for the bare-``not`` fallbacks).
-        def not_positive(x):
-            if x is not None:
-                return not (x > 0)
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(not_positive, BooleanType())
-            self.assertTrue(pudf.transpiled, "not(comparison) should transpile")
-            df = self.spark.createDataFrame([(1,), (0,), (-1,), (None,)], "a long")
-            self.assertEqual(
-                [r[0] for r in df.select(pudf("a")).collect()],
-                [False, True, True, None],
-            )
-
-    def test_udf_transpile_nested_boolean(self):
-        # Compose and/or over comparisons: ``(x > 0 and y > 0) or z == 0``.
-        def nested(x, y, z):
-            if x is not None and y is not None:
-                return (x > 0 and y > 0) or z == 0
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(nested, BooleanType())
-            self.assertTrue(pudf.transpiled, "nested boolean should transpile")
-            for x, y, z, expected in [
-                (1, 1, 5, True),
-                (-1, 1, 0, True),
-                (-1, 1, 5, False),
-                (1, -1, 9, False),
-            ]:
-                with self.subTest(x=x, y=y, z=z):
-                    df = self.spark.createDataFrame([(x, y, z)], "a long, b long, c long")
-                    self.assertEqual(df.select(pudf("a", "b", "c")).first()[0], expected)
-
-    def test_udf_transpile_string_equality_and_ordering(self):
-        # String columns transpile for ``==`` and ``<`` like numerics do.
-        def eq_foo(x):
-            if x is not None:
-                return x == "foo"
-
-        def lt_m(x):
-            if x is not None:
-                return x < "m"
-
-        with self.sql_conf(_TRANSPILE_ON):
-            eq_udf = UserDefinedFunction(eq_foo, BooleanType())
-            lt_udf = UserDefinedFunction(lt_m, BooleanType())
-            self.assertTrue(eq_udf.transpiled and lt_udf.transpiled)
-            eq_df = self.spark.createDataFrame([("foo",), ("bar",), (None,)], "a string")
-            self.assertEqual(
-                [r[0] for r in eq_df.select(eq_udf("a")).collect()], [True, False, None]
-            )
-            lt_df = self.spark.createDataFrame([("a",), ("z",), (None,)], "a string")
-            self.assertEqual(
-                [r[0] for r in lt_df.select(lt_udf("a")).collect()], [True, False, None]
-            )
-
-    def test_udf_transpile_if_elif_else(self):
-        # ``elif`` is a nested ``If`` in the else slot (one statement), so a
-        # null-safe if/elif/else chain transpiles.
-        def classify(x):
+        def if_elif_else(x):
             if x is None:
                 return -1
             elif x == 0:
@@ -1070,82 +928,88 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             else:
                 return 1
 
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(classify, LongType())
-            self.assertTrue(pudf.transpiled, "if/elif/else should transpile")
-            df = self.spark.createDataFrame([(None,), (0,), (5,), (-3,)], "a long")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [-1, 0, 1, 1])
+        cases = [
+            ("modulo_sign", modulo, L, [(7, 3), (7, -3), (-7, 3), (-7, -3), (0, 3), (5, -5)],
+             "a long, b long", ("a", "b"), [1, -2, 2, -1, 0, 0]),
+            ("subtract_order", subtract, L, [(5, 3), (3, 5)], "a long, b long", ("a", "b"), [2, -2]),
+            ("multiply", multiply, L, [(4, 3), (-2, 5)], "a long, b long", ("a", "b"), [12, -10]),
+            ("power", power, L, [(6,), (-3,), (0,)], "a long", ("a",), [36, 9, 0]),
+            ("double_negate", double_neg, L, [(5,), (-3,)], "a long", ("a",), [5, -3]),
+            ("unary_plus_minus", unary_pm, L, [(5,), (-3,)], "a long", ("a",), [-5, 3]),
+            ("constant_body", constant, L, [(1,), (999,)], "a long", ("a",), [42, 42]),
+            ("not_comparison", not_pos, B, [(1,), (0,), (-1,), (None,)], "a long", ("a",),
+             [False, True, True, None]),
+            ("nested_boolean", nested, B, [(1, 1, 5), (-1, 1, 0), (-1, 1, 5), (1, -1, 9)],
+             "a long, b long, c long", ("a", "b", "c"), [True, True, False, False]),
+            ("string_equality", str_eq, B, [("foo",), ("bar",), (None,)], "a string", ("a",),
+             [True, False, None]),
+            ("string_ordering", str_lt, B, [("a",), ("z",), (None,)], "a string", ("a",),
+             [True, False, None]),
+            ("reversed_less_than", rev_lt, B, [(1,), (0,), (-1,)], "a long", ("a",),
+             [True, False, False]),
+            ("reversed_equals", rev_eq, B, [(5,), (3,), (None,)], "a long", ("a",),
+             [True, False, False]),
+            ("none_equals_col", none_eq, B, [(None,), (5,)], "a long", ("a",), [True, False]),
+            ("column_lt_column", col_lt, B, [(1, 2), (2, 1), (1, 1)], "a long, b long", ("a", "b"),
+             [True, False, False]),
+            ("if_elif_else", if_elif_else, L, [(None,), (0,), (5,), (-3,)], "a long", ("a",),
+             [-1, 0, 1, 1]),
+            ("assigned_lambda", assigned, L, [(1,), (10,)], "a long", ("a",), [2, 11]),
+        ]
+        for label, func, rt, rows, schema, cols, expected in cases:
+            with self.subTest(label):
+                transpiled, values = self._run(func, rt, rows, schema, *cols)
+                self.assertTrue(transpiled, f"{label}: should transpile")
+                self.assertEqual(values, expected, label)
 
-    def test_udf_transpile_filter_elision(self):
-        # A transpiled boolean UDF used in ``filter`` is elided like one used
-        # in ``select`` (extends coverage beyond projection).
-        def gt5(x):
-            if x is not None:
-                return x > 5
+    def test_udf_transpile_callable_object_self_offset(self):
+        # A callable instance carries ``self``; the extractor offsets it so a/b
+        # map to _udf_param_0/_udf_param_1 (non-commutative body proves order).
+        class SubAB:
+            def __call__(self, a, b):
+                return a - b
 
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(gt5, BooleanType())
-            self.assertTrue(pudf.transpiled, "filter predicate should transpile")
-            df = self.spark.createDataFrame([(3,), (7,), (1,), (None,)], "a long")
-            fdf = df.filter(pudf("a"))
-            self.assertEqual([r[0] for r in fdf.collect()], [7])
-            self.assertEqual(
-                0,
-                self._eval_python_count(fdf),
-                "transpiled filter predicate should leave no Python eval node",
-            )
+        self.assertEqual(
+            self._run(SubAB(), LongType(), [(5, 3), (3, 5)], "a long, b long", "a", "b"),
+            (True, [2, -2]),
+        )
 
-    def test_udf_transpile_mixed_chain_elision(self):
-        # Non-convertible (closure) -> convertible (``x + 1``) -> non-convertible
-        # (``/``). Only the middle UDF is rewritten; it is inlined into the
-        # outer UDF's argument, leaving exactly two Python eval nodes.
+    def test_udf_transpile_plan_elision(self):
+        # Transpiled UDFs are elided in filter (not just select); a mixed
+        # non-convertible -> convertible -> non-convertible chain inlines only
+        # the middle UDF, leaving exactly two Python eval nodes.
         offset = 3
-
-        def add_offset(x):  # closure -> fallback
-            if x is not None:
-                return x + offset
-
-        def plus_one(x):  # convertible
-            if x is not None:
-                return x + 1
-
-        def div_two(x):  # `/` -> fallback
-            if x is not None:
-                return x / 2
-
+        gt5 = lambda x: (x > 5) if x is not None else None  # noqa: E731
+        add_offset = lambda x: x + offset  # noqa: E731  closure -> fallback
+        plus_one = lambda x: x + 1  # noqa: E731  convertible
+        div_two = lambda x: x / 2  # noqa: E731  `/` -> fallback
         with self.sql_conf(_TRANSPILE_ON):
+            f = UserDefinedFunction(gt5, BooleanType())
+            self.assertTrue(f.transpiled)
+            fdf = self.spark.createDataFrame([(3,), (7,), (1,), (None,)], "a long").filter(f("a"))
+            self.assertEqual([r[0] for r in fdf.collect()], [7])
+            self.assertEqual(0, self._eval_python_count(fdf))
+
             u1 = UserDefinedFunction(add_offset, LongType())
             u2 = UserDefinedFunction(plus_one, LongType())
             u3 = UserDefinedFunction(div_two, DoubleType())
-            self.assertEqual([], u1.transpiled, "closure UDF must fall back")
-            self.assertTrue(u2.transpiled, "middle UDF must transpile")
-            self.assertEqual([], u3.transpiled, "division UDF must fall back")
-            df = self.spark.createDataFrame([(10,)], "a long")
+            self.assertEqual(([], True, []), (u1.transpiled, bool(u2.transpiled), u3.transpiled))
             chained = (
-                df.select(u1("a").alias("x1"))
-                .select(u2("x1").alias("x2"))
-                .select(u3("x2").alias("x3"))
+                self.spark.createDataFrame([(10,)], "a long")
+                .select(u1("a").alias("x"))
+                .select(u2("x").alias("y"))
+                .select(u3("y").alias("z"))
             )
             self.assertEqual(chained.first()[0], 7.0)  # ((10 + 3) + 1) / 2
-            self.assertEqual(
-                2,
-                self._eval_python_count(chained),
-                "only the two non-convertible UDFs should remain as eval nodes",
-            )
+            self.assertEqual(2, self._eval_python_count(chained))
 
     def test_udf_transpile_config_toggle_no_stale_nodes(self):
-        # A UDF built with the flags ON carries a transpiled expression, but
-        # executing it with the flags OFF must fall back cleanly to interpreted
-        # Python (the optimizer drops the transpiled node) -- no stale or
-        # unevaluable plan node, and a correct result.
-        def plus_one(x):
-            if x is not None:
-                return x + 1
-
+        # Built with the flags on, executed with them off -> clean fallback to
+        # interpreted Python (the optimizer drops the transpiled node), no error.
+        plus_one = lambda x: x + 1  # noqa: E731
         with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(plus_one, LongType())
-            self.assertTrue(pudf.transpiled, "should transpile while flags are on")
-
+            u = UserDefinedFunction(plus_one, LongType())
+            self.assertTrue(u.transpiled)
         with self.sql_conf(
             {
                 "spark.sql.experimental.optimizer.transpilePyUDFs": False,
@@ -1153,112 +1017,27 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             }
         ):
             df = self.spark.createDataFrame([(1,), (5,)], "a long")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [2, 6])
+            self.assertEqual([r[0] for r in df.select(u("a")).collect()], [2, 6])
 
-    def test_udf_transpile_return_type_cast(self):
-        # The lowered expression is cast to the declared return type, so the
-        # output schema and values follow the declared type.
-        def plus_one(x):
-            if x is not None:
-                return x + 1
-
+    def test_udf_transpile_casts_to_return_type(self):
+        # The lowered expression is cast to the declared return type.
+        plus_one = lambda x: x + 1  # noqa: E731
         with self.sql_conf(_TRANSPILE_ON):
-            double_udf = UserDefinedFunction(plus_one, DoubleType())
-            long_udf = UserDefinedFunction(plus_one, LongType())
-            self.assertTrue(double_udf.transpiled and long_udf.transpiled)
-            df = self.spark.createDataFrame([(1,)], "a long")
-            double_col = df.select(double_udf("a").alias("r"))
-            self.assertEqual(double_col.schema["r"].dataType, DoubleType())
-            self.assertEqual(double_col.first()[0], 2.0)
-            self.assertEqual(df.select(long_udf("a")).first()[0], 2)
+            d = UserDefinedFunction(plus_one, DoubleType())
+            col = self.spark.createDataFrame([(1,)], "a long").select(d("a").alias("r"))
+            self.assertEqual(col.schema["r"].dataType, DoubleType())
+            self.assertEqual(col.first()[0], 2.0)
+        self.assertEqual(self._run(plus_one, LongType(), [(1,)], "a long", "a"), (True, [2]))
 
-    def test_udf_transpile_reversed_operand_comparison(self):
-        # Literal-on-the-left comparisons exercise the asymmetry in
-        # ``_lower_value_compare`` / ``_lower_eq`` (which take the left column
-        # and the right AST node).
-        def lit_lt(x):
-            if x is not None:
-                return 0 < x
+    def test_udf_transpile_falls_back(self):
+        # Shapes that must NOT transpile (and still compute via Python):
+        # inline/wrapped/partial lambdas, default/variadic/keyword-only args,
+        # and string-literal operator overloading (+, %, * over text).
+        import functools
 
-        def lit_eq(x):
-            return 5 == x
+        def wrapper(fn):
+            return fn
 
-        def none_eq(x):
-            return None == x  # noqa: E711
-
-        with self.sql_conf(_TRANSPILE_ON):
-            lt_udf = UserDefinedFunction(lit_lt, BooleanType())
-            eq_udf = UserDefinedFunction(lit_eq, BooleanType())
-            none_udf = UserDefinedFunction(none_eq, BooleanType())
-            self.assertTrue(lt_udf.transpiled and eq_udf.transpiled and none_udf.transpiled)
-
-            lt_df = self.spark.createDataFrame([(1,), (0,), (-1,), (None,)], "a long")
-            self.assertEqual(
-                [r[0] for r in lt_df.select(lt_udf("a")).collect()],
-                [True, False, False, None],
-            )
-            eq_df = self.spark.createDataFrame([(5,), (3,), (None,)], "a long")
-            self.assertEqual(
-                [r[0] for r in eq_df.select(eq_udf("a")).collect()],
-                [True, False, False],
-            )
-            none_df = self.spark.createDataFrame([(None,), (5,)], "a long")
-            self.assertEqual(
-                [r[0] for r in none_df.select(none_udf("a")).collect()],
-                [True, False],
-            )
-
-    def test_udf_transpile_column_to_column_ordering(self):
-        # Ordering comparison between two parameters (not a literal).
-        def a_lt_b(a, b):
-            if a is not None and b is not None:
-                return a < b
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(a_lt_b, BooleanType())
-            self.assertTrue(pudf.transpiled, "column-to-column ordering should transpile")
-            for a, b, expected in [(1, 2, True), (2, 1, False), (1, 1, False)]:
-                with self.subTest(a=a, b=b):
-                    df = self.spark.createDataFrame([(a, b)], "a long, b long")
-                    self.assertEqual(df.select(pudf("a", "b")).first()[0], expected)
-
-    def test_udf_transpile_nested_unary(self):
-        # Stacked unary ops: ``- -x`` (USub of USub) and ``+(-x)`` (UAdd of
-        # USub, where UAdd is identity).
-        def double_neg(x):
-            if x is not None:
-                return - -x
-
-        def plus_neg(x):
-            if x is not None:
-                return +(-x)
-
-        with self.sql_conf(_TRANSPILE_ON):
-            dn_udf = UserDefinedFunction(double_neg, LongType())
-            pn_udf = UserDefinedFunction(plus_neg, LongType())
-            self.assertTrue(dn_udf.transpiled and pn_udf.transpiled)
-            df = self.spark.createDataFrame([(5,), (-3,)], "a long")
-            self.assertEqual([r[0] for r in df.select(dn_udf("a")).collect()], [5, -3])
-            self.assertEqual([r[0] for r in df.select(pn_udf("a")).collect()], [-5, 3])
-
-    def test_udf_transpile_constant_body(self):
-        # A body that ignores its parameter and returns a constant lowers to a
-        # literal (no parameter placeholder needed).
-        def always_42(x):
-            return 42
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(always_42, LongType())
-            self.assertTrue(pudf.transpiled, "constant body should transpile")
-            df = self.spark.createDataFrame([(1,), (999,)], "a long")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [42, 42])
-
-    def test_udf_transpile_default_args_fall_back(self):
-        # The positional ``_udf_param_N`` placeholder scheme can't represent
-        # default / variadic / keyword-only arguments: a call site may omit a
-        # defaulted argument, dangling a placeholder past the bound arguments.
-        # Such functions must fall back to interpreted Python (regression for
-        # the INVALID_UDF_PARAMETER_PLACEHOLDER_INDEX failure).
         def with_default(a, b=0):
             return a + 10 * b
 
@@ -1268,193 +1047,98 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         def with_kwargs(a, **opts):
             return a
 
+        base = lambda v, w: v + w  # noqa: E731
+        concat_right = lambda a: a + "!"  # noqa: E731
+        concat_left = lambda a: "pre-" + a  # noqa: E731
+        percent_fmt = lambda x: "n=%d" % x  # noqa: E731
+        repeat = lambda x: "ab" * x  # noqa: E731
         with self.sql_conf(_TRANSPILE_ON):
-            for label, func in [
-                ("default", with_default),
-                ("varargs", with_varargs),
-                ("kwargs", with_kwargs),
+            # inline / wrapped / partial lambdas -> source can't be extracted
+            self.assertEqual([], UserDefinedFunction(lambda v: v + 1, LongType()).transpiled)
+            self.assertEqual([], UserDefinedFunction(wrapper(lambda v: v + 1), LongType()).transpiled)
+            self.assertEqual([], UserDefinedFunction(functools.partial(base, 1), LongType()).transpiled)
+            for label, func, rt in [
+                ("default_arg", with_default, LongType()),
+                ("varargs", with_varargs, LongType()),
+                ("kwargs", with_kwargs, LongType()),
+                ("concat_right", concat_right, StringType()),
+                ("concat_left", concat_left, StringType()),
+                ("percent_format", percent_fmt, StringType()),
+                ("repeat", repeat, StringType()),
             ]:
-                with self.subTest(case=label):
-                    pudf = UserDefinedFunction(func, LongType())
-                    self.assertEqual(
-                        [], pudf.transpiled, f"{label}: must fall back, not transpile"
-                    )
-            # The defaulted UDF still works (interpreted), with and without
-            # the optional argument.
-            df = self.spark.createDataFrame([(5,)], "a long")
-            pudf = UserDefinedFunction(with_default, LongType())
-            self.assertEqual(df.select(pudf("a")).first()[0], 5)  # b defaults to 0
-            self.assertEqual(df.select(pudf("a", "a")).first()[0], 55)  # 5 + 10 * 5
-
-    # ------------------------------------------------------------------
-    # Incorrect-transpilation hazards (correctness audit). Python overloads
-    # +, *, % for text and treats NULL / NaN / overflow differently from
-    # Spark, and the transpiler has no column-type info, so it assumes numeric
-    # operands. String/bytes *literal* operands are now refused (fall back);
-    # the cases that still transpile are pinned here as documented divergences
-    # so a future change to any of them is noticed.
-    # ------------------------------------------------------------------
-
-    def test_udf_transpile_string_literal_operator_overloading_falls_back(self):
-        # Python's +, *, % over text (concatenation, repetition, %-formatting)
-        # are NOT arithmetic. A string/bytes literal operand makes that
-        # statically detectable, so the transpiler falls back rather than emit
-        # a numeric op over text (which Spark would reject or miscompute).
-        def concat_right(a):
-            if a is not None:
-                return a + "!"
-
-        def concat_left(a):
-            if a is not None:
-                return "pre-" + a
-
-        def percent_format(x):
-            if x is not None:
-                return "n=%d" % x
-
-        def repeat(x):
-            if x is not None:
-                return "ab" * x
-
-        with self.sql_conf(_TRANSPILE_ON):
-            cr = UserDefinedFunction(concat_right, StringType())
-            cl = UserDefinedFunction(concat_left, StringType())
-            pf = UserDefinedFunction(percent_format, StringType())
-            rp = UserDefinedFunction(repeat, StringType())
-            for label, pudf in [
-                ("concat_right", cr),
-                ("concat_left", cl),
-                ("percent_format", pf),
-                ("repeat", rp),
-            ]:
-                with self.subTest(case=label):
-                    self.assertEqual([], pudf.transpiled, f"{label}: must fall back")
-            # Interpreted Python still produces the right text.
+                with self.subTest(label):
+                    self.assertEqual([], UserDefinedFunction(func, rt).transpiled, label)
+            # Fell back -> interpreted Python still computes correctly.
             sdf = self.spark.createDataFrame([("hi",)], "a string")
-            self.assertEqual(sdf.select(cr("a")).first()[0], "hi!")
-            self.assertEqual(sdf.select(cl("a")).first()[0], "pre-hi")
-            idf = self.spark.createDataFrame([(5,)], "a long")
-            self.assertEqual(idf.select(pf("a")).first()[0], "n=5")
-            self.assertEqual(idf.select(rp("a")).first()[0], "ababababab")  # "ab" * 5
+            self.assertEqual(
+                sdf.select(UserDefinedFunction(concat_right, StringType())("a")).first()[0], "hi!"
+            )
+            wd = UserDefinedFunction(with_default, LongType())
+            num = self.spark.createDataFrame([(5,)], "a long")
+            self.assertEqual(
+                [num.select(wd("a")).first()[0], num.select(wd("a", "a")).first()[0]], [5, 55]
+            )
 
-    def test_udf_transpile_string_column_arithmetic(self):
-        # A string *column* combined with a number can't be detected at
-        # transpile time (no schema info). For `+` this stays a documented
-        # divergence: Spark coerces "10" + 5 -> 15 where Python raises
-        # TypeError. For `*` the transpiler now guards at runtime so a string
-        # operand raises loudly instead of silently miscomputing ("2" * 3 used
-        # to yield 6, not Python's "222").
-        def col_plus_5(a):
-            if a is not None:
-                return a + 5
+    def test_udf_transpile_known_value_divergences(self):
+        # Transpile but DIVERGE from Python (need runtime type/value info to
+        # fix; documented in transpile.py). Pinned so a future fix is noticed:
+        # unguarded arithmetic on NULL yields NULL (Python raises TypeError);
+        # NaN > 0 is True (Python False; Spark orders NaN highest); int == "5"
+        # coerces to True (Python False); string-column + number coerces
+        # ("10" + 5 -> 15; Python raises).
+        unguarded = lambda x: x + 1  # noqa: E731
+        nan_gt = lambda x: (x > 0) if x is not None else None  # noqa: E731
+        eq_strlit = lambda x: (x == "5") if x is not None else None  # noqa: E731
+        strcol_plus = lambda a: (a + 5) if a is not None else None  # noqa: E731
+        cases = [
+            ("unguarded_null", unguarded, LongType(), [(None,), (5,)], "a long", ("a",), [None, 6]),
+            ("nan_gt_zero", nan_gt, BooleanType(), [(float("nan"),), (1.0,)], "a double", ("a",),
+             [True, True]),
+            ("int_eq_strlit", eq_strlit, BooleanType(), [(5,), (3,)], "a long", ("a",),
+             [True, False]),
+            ("strcol_plus_num", strcol_plus, LongType(), [("10",)], "a string", ("a",), [15]),
+        ]
+        for label, func, rt, rows, schema, cols, expected in cases:
+            with self.subTest(label):
+                transpiled, values = self._run(func, rt, rows, schema, *cols)
+                self.assertTrue(transpiled, label)
+                self.assertEqual(values, expected, label)
 
-        def col_times_3(a):
-            if a is not None:
-                return a * 3
-
-        with self.sql_conf(_TRANSPILE_ON):
-            plus_udf = UserDefinedFunction(col_plus_5, LongType())
-            times_udf = UserDefinedFunction(col_times_3, StringType())
-            self.assertTrue(plus_udf.transpiled and times_udf.transpiled)
-            # `+`: KNOWN DIVERGENCE -- Spark coerces "10" + 5 to 15; Python raises.
-            num_df = self.spark.createDataFrame([("10",)], "a string")
-            self.assertEqual(num_df.select(plus_udf("a")).first()[0], 15)
-            # `*`: a string operand now raises rather than silently coercing
-            # (both a numeric-looking "2" and a non-numeric "ab").
-            for val in ["2", "ab"]:
-                with self.subTest(times_value=val):
-                    sdf = self.spark.createDataFrame([(val,)], "a string")
+    def test_udf_transpile_known_raise_divergences(self):
+        # Transpile but raise where Python differs: overflow under ANSI vs
+        # Python bigint (SPARK-55210); ``% 0`` (both raise); and string-column
+        # ``*`` is type-guarded to raise rather than silently coerce
+        # ("2" * 3 -> 6 instead of Python's "222").
+        overflow = lambda x: x * x  # noqa: E731
+        modulo_zero = lambda x: x % 0  # noqa: E731
+        strcol_times = lambda a: a * 3  # noqa: E731
+        cases = [
+            ("overflow", overflow, LongType(), [(4000000000,)], "a long", ("a",), "OVERFLOW"),
+            ("modulo_by_zero", modulo_zero, LongType(), [(5,)], "a long", ("a",), "ZERO"),
+            ("strcol_times_numeric", strcol_times, StringType(), [("2",)], "a string", ("a",),
+             "NUMERIC"),
+            ("strcol_times_text", strcol_times, StringType(), [("ab",)], "a string", ("a",),
+             "NUMERIC"),
+        ]
+        for label, func, rt, rows, schema, cols, needle in cases:
+            with self.subTest(label):
+                with self.sql_conf(_TRANSPILE_ON):
+                    u = UserDefinedFunction(func, rt)
+                    self.assertTrue(u.transpiled, label)
+                    df = self.spark.createDataFrame(rows, schema)
                     with self.assertRaises(Exception) as ctx:
-                        sdf.select(times_udf("a")).collect()
-                    self.assertIn("numeric", str(ctx.exception).lower())
+                        df.select(u(*cols)).collect()
+                    self.assertIn(needle, str(ctx.exception).upper(), label)
 
-    def test_udf_transpile_power_precision_known_divergence(self):
-        # KNOWN DIVERGENCE: `**` lowers to Spark `pow`, which returns DOUBLE, so
-        # beyond ~2**53 the exact integer can't be represented and the
-        # transpiled result is off by rounding where Python keeps the exact int.
-        # Values within the safe range still match (see the param-order test);
-        # this pins the boundary behavior as a documented limitation.
-        def square(x):
-            if x is not None:
-                return x ** 2
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(square, LongType())
-            self.assertTrue(pudf.transpiled)
-            x = 134217729  # 2**27 + 1; exact square exceeds double's 2**53 range
-            df = self.spark.createDataFrame([(x,)], "a long")
-            self.assertEqual(df.select(pudf("a")).first()[0], 18014398777917440)
-            self.assertNotEqual(x * x, 18014398777917440)  # Python's exact value differs
-
-    def test_udf_transpile_unguarded_arithmetic_on_null_known_divergence(self):
-        # KNOWN DIVERGENCE: arithmetic is not null-guarded (unlike the ordering
-        # comparisons, which raise to mirror Python). An UNguarded `x + 1` thus
-        # yields NULL on a NULL input, whereas interpreted Python raises
-        # TypeError (None + 1). Guard with `is not None` for parity.
-        def add_one_unguarded(x):
-            return x + 1
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(add_one_unguarded, LongType())
-            self.assertTrue(pudf.transpiled)
-            df = self.spark.createDataFrame([(None,), (5,)], "a long")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [None, 6])
-
-    def test_udf_transpile_overflow_and_modulo_by_zero_raise(self):
-        # Under ANSI the transpiled arithmetic raises on overflow and on
-        # modulo-by-zero. Interpreted Python would promote `x * x` to a big int
-        # (a divergence; see SPARK-55210), and raises ZeroDivisionError for
-        # `x % 0` (compatible -- both raise).
-        def square(x):
-            if x is not None:
-                return x * x
-
-        def mod_zero(x):
-            if x is not None:
-                return x % 0
-
-        with self.sql_conf(_TRANSPILE_ON):
-            sq = UserDefinedFunction(square, LongType())
-            mz = UserDefinedFunction(mod_zero, LongType())
-            self.assertTrue(sq.transpiled and mz.transpiled)
-            big = self.spark.createDataFrame([(4000000000,)], "a long")  # 4e9^2 overflows long
-            with self.assertRaises(Exception) as ctx:
-                big.select(sq("a")).collect()
-            self.assertIn("OVERFLOW", str(ctx.exception).upper())
-            zero = self.spark.createDataFrame([(5,)], "a long")
-            with self.assertRaises(Exception) as ctx2:
-                zero.select(mz("a")).collect()
-            self.assertIn("ZERO", str(ctx2.exception).upper())
-
-    def test_udf_transpile_nan_comparison_known_divergence(self):
-        # KNOWN DIVERGENCE: Spark orders NaN as greater than every value, so a
-        # transpiled `x > 0` returns True for NaN, whereas interpreted Python
-        # (`nan > 0`) returns False. The null-guard checks isNull, not isNaN.
-        def gt_zero(x):
-            if x is not None:
-                return x > 0
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(gt_zero, BooleanType())
-            self.assertTrue(pudf.transpiled)
-            df = self.spark.createDataFrame([(float("nan"),), (1.0,)], "a double")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [True, True])
-
-    def test_udf_transpile_cross_type_equality_coerces(self):
-        # KNOWN DIVERGENCE: comparing a column to a literal of a different type
-        # coerces in Spark, so a transpiled `x == "5"` on an int column is True
-        # for 5, whereas Python's `5 == "5"` is False (no cross-type coercion).
-        # Equality with a string literal is intentionally NOT forced to fall
-        # back, since `stringcol == "5"` is a legitimate, correct comparison.
-        def eq_str_five(x):
-            if x is not None:
-                return x == "5"
-
-        with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(eq_str_five, BooleanType())
-            self.assertTrue(pudf.transpiled)
-            df = self.spark.createDataFrame([(5,), (3,)], "a long")
-            self.assertEqual([r[0] for r in df.select(pudf("a")).collect()], [True, False])
+    def test_udf_transpile_power_precision_divergence(self):
+        # `**` -> Spark pow (DOUBLE); beyond ~2**53 it loses precision where
+        # Python keeps exact ints. Documented limitation.
+        square = lambda x: x ** 2  # noqa: E731
+        x = 134217729  # 2**27 + 1; exact square exceeds double's 2**53 range
+        self.assertEqual(
+            self._run(square, LongType(), [(x,)], "a long", "a"), (True, [18014398777917440])
+        )
+        self.assertNotEqual(x * x, 18014398777917440)  # Python's exact value differs
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -319,21 +319,24 @@ class CatalystTranspiler(AbstractTranspiler):
         """
         match node:
             case ast.Constant(value=v):
-                # bool subclasses int, so reject it first. Only real int/float
-                # are "numeric" and only str is "string". bool/None/complex/
-                # Ellipsis/bytes have no faithful numeric-or-string operator
-                # lowering (Spark can't multiply a boolean, has no complex type,
-                # and `repeat` rejects binary), so we raise to drop this variant
-                # and fall back to the Python UDF rather than emit an option that
-                # fails CheckAnalysis (e.g. `x * True`) or silently diverges
-                # (e.g. `x + None` -> NULL where Python raises TypeError).
-                if isinstance(v, bool) or not isinstance(v, (int, float, str)):
-                    raise UnsupportedOperationException(
-                        f"constant {v!r} ({type(v).__name__}) has no numeric or "
-                        "string operator lowering; falling back to interpreted "
-                        "Python"
-                    )
-                return "string" if isinstance(v, str) else "numeric"
+                # bool subclasses int, so classify it first: int/float -> numeric,
+                # str -> string, bool -> bool, bytes -> binary. None/complex/
+                # Ellipsis have no usable Spark column type, so raise to drop this
+                # variant and fall back rather than emit an option that fails
+                # CheckAnalysis or silently diverges (e.g. `x + None` -> NULL where
+                # Python raises TypeError).
+                if isinstance(v, bool):
+                    return "bool"
+                if isinstance(v, bytes):
+                    return "binary"
+                if isinstance(v, (int, float)):
+                    return "numeric"
+                if isinstance(v, str):
+                    return "string"
+                raise UnsupportedOperationException(
+                    f"constant {v!r} ({type(v).__name__}) has no usable column "
+                    "category; falling back to interpreted Python"
+                )
             case ast.Name(id=name) if name in params:
                 index = params.index(name)
                 if params and params[0] == "self":
@@ -624,33 +627,37 @@ def _get_transpilers(session: "SparkSession") -> List[AbstractTranspiler]:
 
 
 def _annotation_category(annotation: Optional[ast.AST]) -> Optional[str]:
-    """Map a parameter's type annotation to ``"numeric"`` / ``"string"``, or
-    ``None`` when it's absent or unrecognised (the caller then tries both)."""
+    """Map a parameter's type annotation to a category
+    (``"numeric"``/``"string"``/``"bool"``/``"binary"``), or ``None`` when it's
+    absent or unrecognised (the caller then tries both numeric and string)."""
     name: Optional[str] = None
     if isinstance(annotation, ast.Name):
         name = annotation.id
     elif isinstance(annotation, ast.Constant) and isinstance(annotation.value, str):
         name = annotation.value  # stringized annotation, e.g. def f(a: "int")
-    # Only str -> "string" and int/float -> "numeric". bool/complex/bytes are
-    # deliberately left unrecognised (-> None, "try both") so they fall back
-    # like any other unsupported type: bool/complex have no usable lowering
-    # (Spark can't do arithmetic on booleans and has no complex type) and bytes
-    # is BinaryType, which the string lowerings (concat/repeat) reject. This
-    # mirrors the constant handling in ``_category``.
+    # str -> "string", int/float -> "numeric", bool -> "bool", bytes -> "binary"
+    # (matching the constant handling in ``_category``). complex and anything
+    # unrecognised return None so the caller tries both numeric and string.
     if name == "str":
         return "string"
     if name in ("int", "float"):
         return "numeric"
+    if name == "bool":
+        return "bool"
+    if name == "bytes":
+        return "binary"
     return None
 
 
 def _param_category_combos(function_ast: ast.FunctionDef, public_params: List[str]) -> List[dict]:
-    """Per-variant maps ``{public_param_index -> "numeric"|"string"}``.
+    """Per-variant maps ``{public_param_index -> category}`` where category is
+    one of ``"numeric"``/``"string"``/``"bool"``/``"binary"``.
 
     A typed param (``def f(a: str, b: int)``) is pinned to its category; an
-    untyped param is tried as both. To cap plan growth, when more than three
-    params are untyped we emit only the all-numeric and all-string variants
-    (encourage typing inputs to keep the matrix small).
+    untyped param is tried as both numeric and string. To cap plan growth, when
+    more than three params are untyped we collapse the untyped ones to the
+    all-numeric and all-string variants (encourage typing inputs to keep the
+    matrix small) while keeping every typed param pinned.
     """
     n = len(public_params)
     public_args = function_ast.args.args[len(function_ast.args.args) - n :]
@@ -664,9 +671,12 @@ def _param_category_combos(function_ast: ast.FunctionDef, public_params: List[st
         else:
             candidates.append([cat])
     if untyped > 3:
+        # Cap the 2**untyped blow-up, but keep each typed param pinned to its
+        # category (a single-element ``candidates`` entry); only the untyped
+        # params collapse to the all-numeric / all-string pair.
         return [
-            {i: "numeric" for i in range(n)},
-            {i: "string" for i in range(n)},
+            {i: c[0] if len(c) == 1 else fill for i, c in enumerate(candidates)}
+            for fill in ("numeric", "string")
         ]
     return [{i: choice[i] for i in range(n)} for choice in itertools.product(*candidates)] or [{}]
 

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -328,7 +328,7 @@ class CatalystTranspiler(AbstractTranspiler):
                     f"operands of `{type(op).__name__}` are not type-compatible "
                     "for this input-type variant"
                 )
-            case ast.Return(value=value):
+            case ast.Return(value=value) if value is not None:
                 return self._category(params, value)
             case _:
                 # Comparisons / boolean ops / unary / None / ternary don't drive
@@ -615,9 +615,7 @@ def _annotation_category(annotation: Optional[ast.AST]) -> Optional[str]:
     return None
 
 
-def _param_category_combos(
-    function_ast: ast.FunctionDef, public_params: List[str]
-) -> List[dict]:
+def _param_category_combos(function_ast: ast.FunctionDef, public_params: List[str]) -> List[dict]:
     """Per-variant maps ``{public_param_index -> "numeric"|"string"}``.
 
     A typed param (``def f(a: str, b: int)``) is pinned to its category; an
@@ -641,9 +639,7 @@ def _param_category_combos(
             {i: "numeric" for i in range(n)},
             {i: "string" for i in range(n)},
         ]
-    return [
-        {i: choice[i] for i in range(n)} for choice in itertools.product(*candidates)
-    ] or [{}]
+    return [{i: choice[i] for i in range(n)} for choice in itertools.product(*candidates)] or [{}]
 
 
 def _get_src_ast_from_func(func: Callable) -> Tuple[Optional[str], Optional[ast.AST]]:

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -25,11 +25,21 @@ etc.); running them under non-ANSI mode would silently diverge from the
 Python interpretation in ways we don't currently track. If you flip
 transpilation on with ANSI off the UDF will fall back to interpreted
 Python execution and a warning is logged at UDF construction time.
+
+Python's ``+`` and ``*`` are overloaded for text (concat / repeat), so an
+untyped parameter is transpiled into one option per input-type category
+(numeric and string) and the JVM picks the one matching the bound column
+types -- falling back to interpreted Python when none fit. Annotating the
+UDF's parameters (e.g. ``def f(a: int, b: str)``) pins each category and
+keeps the option matrix small; prefer doing so. To bound plan growth,
+functions with more than three untyped parameters only emit the
+all-numeric and all-string variants.
 """
 
 import ast
 from typing import Any, Callable, List, Optional, Tuple, TYPE_CHECKING
 import inspect
+import itertools
 import textwrap
 from pyspark.errors import UnsupportedOperationException
 from pyspark.sql.column import Column
@@ -37,11 +47,12 @@ from pyspark.sql.functions import (
     abs as _abs,
     coalesce,
     col,
+    concat,
     lit,
     pmod,
     raise_error,
+    repeat,
     sign,
-    typeof,
     when,
 )
 
@@ -70,6 +81,7 @@ class AbstractTranspiler(object):
         function_ast: ast.FunctionDef,
         params: List[str],
         returnType: "DataTypeOrString",
+        param_categories: Optional[dict] = None,
     ) -> Optional[Column]:
         pass
 
@@ -283,45 +295,45 @@ class CatalystTranspiler(AbstractTranspiler):
         )
         return when(null_guard, raise_error(err)).otherwise(op(left_col, right_col))
 
-    def _guard_numeric_binop(
-        self,
-        left: ast.AST,
-        left_col: Column,
-        right: ast.AST,
-        right_col: Column,
-        result: Column,
-        op_repr: str,
-    ) -> Column:
-        """Guard an arithmetic result against textual column operands at runtime.
+    def _category(self, params: List[str], node: ast.AST) -> str:
+        """Infer ``"numeric"`` or ``"string"`` for ``node`` under the current
+        ``self._param_categories`` assumption (set per input-type variant).
 
-        The transpiler has no column types, and Python overloads ``+`` / ``*`` /
-        ``%`` for text (concatenation / repetition / %-formatting) while ``-`` /
-        ``**`` reject it; Spark would instead silently coerce a numeric-looking
-        string (``"2" * 3 -> 6``, not ``"222"``) or raise a cast error. A single
-        Catalyst expression can't return both the textual and numeric outcomes,
-        so for any operand that is not a numeric literal we check its runtime
-        type and raise loudly when it is string/binary. String/bytes *literals*
-        never reach here -- they force a fall back to interpreted Python earlier.
+        Drives operator selection (``+`` -> add vs concat, ``*`` -> multiply vs
+        repeat) and raises ``UnsupportedOperationException`` when an operator's
+        operands are type-incompatible, so the caller drops that variant and the
+        JVM picks another option / falls back to the Python UDF.
         """
-        checks = [
-            typeof(col).isin("string", "binary")
-            for node, col in ((left, left_col), (right, right_col))
-            if not isinstance(node, ast.Constant)
-        ]
-        if not checks:
-            return result
-        textual = checks[0]
-        for extra in checks[1:]:
-            textual = textual | extra
-        err = raise_error(
-            lit(
-                f"Python UDF transpiler: `{op_repr}` requires numeric operands; "
-                "a string/bytes operand has no arithmetic meaning here (Python "
-                "would concatenate, repeat, format, or raise). Guard or rewrite "
-                "the UDF."
-            )
-        )
-        return when(textual, err).otherwise(result)
+        match node:
+            case ast.Constant(value=v):
+                return "string" if isinstance(v, (str, bytes)) else "numeric"
+            case ast.Name(id=name) if name in params:
+                index = params.index(name)
+                if params and params[0] == "self":
+                    index -= 1
+                return self._param_categories.get(index, "numeric")
+            case ast.BinOp(left=left, op=op, right=right):
+                lc = self._category(params, left)
+                rc = self._category(params, right)
+                if isinstance(op, ast.Add) and lc == rc:
+                    return lc  # str + str -> str, num + num -> num
+                if isinstance(op, ast.Mult):
+                    if lc == "numeric" and rc == "numeric":
+                        return "numeric"
+                    if {lc, rc} == {"numeric", "string"}:
+                        return "string"  # str * int / int * str -> repeat
+                if isinstance(op, (ast.Sub, ast.Mod, ast.Pow)) and lc == rc == "numeric":
+                    return "numeric"
+                raise UnsupportedOperationException(
+                    f"operands of `{type(op).__name__}` are not type-compatible "
+                    "for this input-type variant"
+                )
+            case ast.Return(value=value):
+                return self._category(params, value)
+            case _:
+                # Comparisons / boolean ops / unary / None / ternary don't drive
+                # concat/repeat selection; treat as numeric for category purposes.
+                return "numeric"
 
     def _convert_chunk(self, params: List[str], body: ast.AST | None) -> Column:
         match body:
@@ -463,79 +475,60 @@ class CatalystTranspiler(AbstractTranspiler):
                             "is not supported by the transpiler"
                         )
             case ast.BinOp(left=left, op=op, right=right):
-                # Arithmetic operators assume *numeric* operands, but Python
-                # overloads `+` / `*` / `%` for text (concatenation, repetition,
-                # %-formatting) and rejects `-` / `**` on text. Two layers guard
-                # this: (1) a string/bytes *literal* operand is statically
-                # detectable and forces a fall back to interpreted Python, so
-                # `a + "!"` or `"%d" % x` still runs correctly; (2) a non-literal
-                # operand's type is unknown at transpile time, so
-                # `_guard_numeric_binop` adds a runtime check that raises rather
-                # than let Spark silently coerce `"2" * 3 -> 6` or `"10" + 5 ->
-                # 15`. Fully correct text handling would need schema-aware
-                # transpilation; until then we fail loudly instead of wrong.
-                if _is_str_or_bytes_constant(left) or _is_str_or_bytes_constant(right):
-                    raise UnsupportedOperationException(
-                        "binary operator with a string/bytes literal operand "
-                        "(Python text concatenation / repetition / formatting) "
-                        "is not arithmetic and is not supported by the transpiler"
-                    )
+                # Operator selection is driven by the operand *categories* under
+                # the current input-type variant (see ``_category``): Python's
+                # `+` / `*` are overloaded for text. `+` -> add (num,num) or
+                # concat (str,str); `*` -> multiply (num,num) or repeat (str,int
+                # / int,str); `-` / `%` / `**` are numeric-only. Combos that
+                # don't fit (str+int, str-str, ...) raise so this variant is
+                # dropped and the JVM picks another option or falls back to the
+                # Python UDF.
+                #
+                # Value-level divergences remain documented (need runtime value
+                # info, not type): overflow raises ARITHMETIC_OVERFLOW under ANSI
+                # where Python promotes to a big int; arithmetic is not
+                # NULL-guarded (`x + 1` on NULL -> NULL vs Python TypeError); and
+                # `**` -> Spark `pow` (DOUBLE) loses precision for large ints.
+                # TODO (SPARK-55210): map overflow / divide-by-zero precisely.
+                lc = self._category(params, left)
+                rc = self._category(params, right)
                 left_col = self._convert_chunk(params, left)
-                if left_col is None:
-                    raise UnsupportedOperationException(
-                        "BinOp left operand could not be lowered to a Column"
-                    )
                 right_col = self._convert_chunk(params, right)
-                if right_col is None:
-                    raise UnsupportedOperationException(
-                        "BinOp right operand could not be lowered to a Column"
-                    )
                 match op:
-                    # Value-level divergences remain documented (they need
-                    # runtime value info, not just type): overflow raises
-                    # ARITHMETIC_OVERFLOW under ANSI where Python promotes to a
-                    # big int; arithmetic is not NULL-guarded, so `x + 1` on a
-                    # NULL input yields NULL where Python raises TypeError; and
-                    # `**` lowers to Spark `pow` (DOUBLE), losing precision for
-                    # large integers (e.g. (2**27 + 1) ** 2 is off by one).
-                    # TODO (SPARK-55210): map overflow / divide-by-zero to
-                    # Catalyst errors via try-variant functions.
                     case ast.Add():
-                        return self._guard_numeric_binop(
-                            left, left_col, right, right_col, left_col.__add__(right_col), "+"
-                        )
+                        if lc == rc == "string":
+                            return concat(left_col, right_col)
+                        if lc == rc == "numeric":
+                            return left_col.__add__(right_col)
                     case ast.Sub():
-                        return self._guard_numeric_binop(
-                            left, left_col, right, right_col, left_col.__sub__(right_col), "-"
-                        )
+                        if lc == rc == "numeric":
+                            return left_col.__sub__(right_col)
                     case ast.Mult():
-                        return self._guard_numeric_binop(
-                            left, left_col, right, right_col, left_col.__mul__(right_col), "*"
-                        )
+                        if lc == "numeric" and rc == "numeric":
+                            return left_col.__mul__(right_col)
+                        if lc == "string" and rc == "numeric":
+                            return repeat(left_col, right_col.cast("int"))
+                        if lc == "numeric" and rc == "string":
+                            return repeat(right_col, left_col.cast("int"))
                     case ast.Mod():
-                        # Python's `%` takes the sign of the divisor; Spark's
-                        # takes the dividend's. `sign(b) * pmod(sign(b) * a,
-                        # abs(b))` reproduces Python for any non-zero divisor.
-                        sb = sign(right_col)
-                        return self._guard_numeric_binop(
-                            left,
-                            left_col,
-                            right,
-                            right_col,
-                            sb * pmod(sb * left_col, _abs(right_col)),
-                            "%",
-                        )
+                        if lc == rc == "numeric":
+                            # Python's `%` takes the sign of the divisor; Spark's
+                            # takes the dividend's. `sign(b) * pmod(sign(b) * a,
+                            # abs(b))` reproduces Python for any non-zero divisor.
+                            sb = sign(right_col)
+                            return sb * pmod(sb * left_col, _abs(right_col))
                     case ast.Pow():
-                        # `**` lowers to Spark `pow` (DOUBLE); see the precision
-                        # note above.
-                        return self._guard_numeric_binop(
-                            left, left_col, right, right_col, left_col.__pow__(right_col), "**"
-                        )
+                        if lc == rc == "numeric":
+                            return left_col.__pow__(right_col)
                     case _:
                         raise UnsupportedOperationException(
                             f"binary operator {type(op).__name__} is not "
                             "supported by the transpiler"
                         )
+                raise UnsupportedOperationException(
+                    f"`{type(op).__name__}` operands are not type-compatible for "
+                    "this input-type variant"
+                )
             case ast.Return(value=value):
                 return self._convert_chunk(params, value)
             case ast.Constant(value=value):
@@ -569,10 +562,14 @@ class CatalystTranspiler(AbstractTranspiler):
         function_ast: ast.FunctionDef,
         params: List[str],
         returnType: "DataTypeOrString",
+        param_categories: Optional[dict] = None,
     ) -> Optional[Column]:
         # Short circuit on nothing to transpile.
         if src == "" or ast_info is None:
             return None
+        # Per-variant input-type assumption ({public_param_index -> category}),
+        # read by ``_category`` to choose str vs numeric operators.
+        self._param_categories = param_categories or {}
         function_body = function_ast.body
         if len(function_body) != 1:
             raise UnsupportedOperationException(
@@ -603,15 +600,50 @@ def _get_transpilers(session: "SparkSession") -> List[AbstractTranspiler]:
     ]
 
 
-def _is_str_or_bytes_constant(node: ast.AST) -> bool:
-    """True for a literal ``str`` / ``bytes`` operand.
+def _annotation_category(annotation: Optional[ast.AST]) -> Optional[str]:
+    """Map a parameter's type annotation to ``"numeric"`` / ``"string"``, or
+    ``None`` when it's absent or unrecognised (the caller then tries both)."""
+    name: Optional[str] = None
+    if isinstance(annotation, ast.Name):
+        name = annotation.id
+    elif isinstance(annotation, ast.Constant) and isinstance(annotation.value, str):
+        name = annotation.value  # stringized annotation, e.g. def f(a: "int")
+    if name in ("str", "bytes"):
+        return "string"
+    if name in ("int", "float", "complex", "bool"):
+        return "numeric"
+    return None
 
-    Python overloads ``+`` / ``*`` / ``%`` for text (concatenation,
-    repetition, %-formatting); a string/bytes literal operand therefore never
-    denotes arithmetic, so the transpiler refuses such a ``BinOp`` and falls
-    back to interpreted Python rather than emit a numeric op over text.
+
+def _param_category_combos(
+    function_ast: ast.FunctionDef, public_params: List[str]
+) -> List[dict]:
+    """Per-variant maps ``{public_param_index -> "numeric"|"string"}``.
+
+    A typed param (``def f(a: str, b: int)``) is pinned to its category; an
+    untyped param is tried as both. To cap plan growth, when more than three
+    params are untyped we emit only the all-numeric and all-string variants
+    (encourage typing inputs to keep the matrix small).
     """
-    return isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes))
+    n = len(public_params)
+    public_args = function_ast.args.args[len(function_ast.args.args) - n :]
+    candidates: List[List[str]] = []
+    untyped = 0
+    for arg in public_args:
+        cat = _annotation_category(arg.annotation)
+        if cat is None:
+            candidates.append(["numeric", "string"])
+            untyped += 1
+        else:
+            candidates.append([cat])
+    if untyped > 3:
+        return [
+            {i: "numeric" for i in range(n)},
+            {i: "string" for i in range(n)},
+        ]
+    return [
+        {i: choice[i] for i in range(n)} for choice in itertools.product(*candidates)
+    ] or [{}]
 
 
 def _get_src_ast_from_func(func: Callable) -> Tuple[Optional[str], Optional[ast.AST]]:
@@ -696,27 +728,30 @@ def _transpile_func(
     session: "SparkSession",
     func: Callable[..., Any],
     returnType: "DataTypeOrString",
-) -> Tuple[List[Column], List[str], List[str]]:
+) -> Tuple[List[Column], List[str], List[str], List[List[str]]]:
     """
     An experimental internal function that attempts to transpile a callable function.
 
     Returns
     -------
-    list of transpiled functions
+    list of transpiled options (one per backend x input-type variant)
     list of errors as strings
     list of positional parameter names (excluding ``self`` for callable
     instances) -- needed so the caller can resolve named-argument
     invocations to positional order at call time, since the ``_udf_param_N``
     substitution in :class:`UserDefinedPythonFunction` is positional.
+    list of per-option input-type categories (``"numeric"`` / ``"string"`` per
+    public param) -- the JVM picks the option whose categories match the bound
+    column types, or falls back to the Python UDF when none match.
     """
     try:
         src, ast = _get_src_ast_from_func(func)
         if ast is None:
-            return ([], ["Error getting ast for function, cannot transpile"], [])
+            return ([], ["Error getting ast for function, cannot transpile"], [], [])
         # Get the lambda body and parameters
         function_ast = _get_function_from_ast(ast)
         if function_ast is None:
-            return ([], ["Error extracting function body from ast, cannot transpile"], [])
+            return ([], ["Error extracting function body from ast, cannot transpile"], [], [])
         # Default, variadic (``*args`` / ``**kwargs``), keyword-only, and
         # positional-only parameters can't be represented by the positional
         # ``_udf_param_N`` placeholder scheme: a call site may omit a
@@ -740,6 +775,7 @@ def _transpile_func(
                     "positional-only arguments are not supported by the transpiler"
                 ],
                 [],
+                [],
             )
         params = _get_parameter_list(function_ast)
         # Strip ``self`` for the caller-facing param list -- callers will
@@ -747,23 +783,30 @@ def _transpile_func(
         # name ``self`` at the call site.
         public_params = params[1:] if params and params[0] == "self" else list(params)
         transpiled: list[Column] = []
+        input_categories: list[list[str]] = []
         errors = []
+        # One transpiled option per (backend x input-type variant). Untyped
+        # params are tried as both numeric and string so the JVM can pick the
+        # option matching the actual column types (or fall back if none match).
+        combos = _param_category_combos(function_ast, public_params)
         # Maybe multiple transpilers (think CUDA, etc.).
         transpilers = _get_transpilers(session)
         for transpiler in transpilers:
-            try:
-                transpiled_column = transpiler._transpile_from_ast(
-                    src, ast, function_ast, params, returnType
-                )
-                if transpiled_column is not None:
-                    transpiled.append(transpiled_column)
-                else:
-                    errors.append(f"Transpiler {transpiler} returned no column")
-            except Exception as e:
-                errors.append(str(e))
-        return (transpiled, errors, public_params)
+            for combo in combos:
+                try:
+                    transpiled_column = transpiler._transpile_from_ast(
+                        src, ast, function_ast, params, returnType, combo
+                    )
+                    if transpiled_column is not None:
+                        transpiled.append(transpiled_column)
+                        input_categories.append(
+                            [combo.get(i, "numeric") for i in range(len(public_params))]
+                        )
+                except Exception as e:
+                    errors.append(str(e))
+        return (transpiled, errors, public_params, input_categories)
     except Exception as e:
         # Don't re-raise: an inability to transpile must never break a
         # working UDF. The caller treats an empty ``transpiled`` list as a
         # silent fall-back to interpreted Python.
-        return ([], [str(e)], [])
+        return ([], [str(e)], [], [])

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -263,12 +263,12 @@ class CatalystTranspiler(AbstractTranspiler):
     def _lower_value_compare(
         self,
         params: List[str],
-        left_col: Column,
+        left_node: ast.AST,
         right_node: ast.AST,
         op: Callable[[Column, Column], Column],
         op_repr: str,
     ) -> Column:
-        """Lower a value comparison (``<``, ``<=``, ``>``, ``>=``, ``==``, ``!=``).
+        """Lower a value comparison (``<``, ``<=``, ``>``, ``>=``).
 
         Python raises ``TypeError`` when an operand of these operators is
         ``None`` (e.g. ``None > 0``), whereas Spark's three-valued logic
@@ -279,13 +279,26 @@ class CatalystTranspiler(AbstractTranspiler):
         not None: x > 0``) take the otherwise branch, so they never trip
         the raise.
 
-        Two value-level differences from Python remain (they need runtime
-        type/value info, so they are documented, not guarded): Spark orders
-        ``NaN`` as greater than every value, whereas Python's ``NaN``
-        comparisons are all ``False``; and operands of different types are
-        coerced by Spark (e.g. an int column ``> "5"``) where Python raises
-        ``TypeError``.
+        Python also forbids ordering across types (``1 < "a"`` -> TypeError),
+        whereas Spark would coerce the operands and return a (wrong) boolean.
+        We therefore only lower when both operands share a category; a
+        mismatch raises so this variant is dropped and the UDF falls back to
+        interpreted Python rather than silently diverging.
+
+        One value-level difference from Python remains (it needs runtime
+        value info, so it is documented, not guarded): Spark orders ``NaN``
+        as greater than every value, whereas Python's ``NaN`` comparisons
+        are all ``False``.
         """
+        lc = self._category(params, left_node)
+        rc = self._category(params, right_node)
+        if lc != rc:
+            raise UnsupportedOperationException(
+                f"`{op_repr}` compares operands of different categories "
+                f"({lc} vs {rc}); Python would raise TypeError, so the "
+                "transpiler falls back to interpreted Python"
+            )
+        left_col = self._convert_chunk(params, left_node)
         right_col = self._convert_chunk(params, right_node)
         null_guard = left_col.isNull() | right_col.isNull()
         err = lit(
@@ -306,7 +319,21 @@ class CatalystTranspiler(AbstractTranspiler):
         """
         match node:
             case ast.Constant(value=v):
-                return "string" if isinstance(v, (str, bytes)) else "numeric"
+                # bool subclasses int, so reject it first. Only real int/float
+                # are "numeric" and only str is "string". bool/None/complex/
+                # Ellipsis/bytes have no faithful numeric-or-string operator
+                # lowering (Spark can't multiply a boolean, has no complex type,
+                # and `repeat` rejects binary), so we raise to drop this variant
+                # and fall back to the Python UDF rather than emit an option that
+                # fails CheckAnalysis (e.g. `x * True`) or silently diverges
+                # (e.g. `x + None` -> NULL where Python raises TypeError).
+                if isinstance(v, bool) or not isinstance(v, (int, float, str)):
+                    raise UnsupportedOperationException(
+                        f"constant {v!r} ({type(v).__name__}) has no numeric or "
+                        "string operator lowering; falling back to interpreted "
+                        "Python"
+                    )
+                return "string" if isinstance(v, str) else "numeric"
             case ast.Name(id=name) if name in params:
                 index = params.index(name)
                 if params and params[0] == "self":
@@ -322,7 +349,7 @@ class CatalystTranspiler(AbstractTranspiler):
                         return "numeric"
                     if {lc, rc} == {"numeric", "string"}:
                         return "string"  # str * int / int * str -> repeat
-                if isinstance(op, (ast.Sub, ast.Mod, ast.Pow)) and lc == rc == "numeric":
+                if isinstance(op, (ast.Sub, ast.Mod)) and lc == rc == "numeric":
                     return "numeric"
                 raise UnsupportedOperationException(
                     f"operands of `{type(op).__name__}` are not type-compatible "
@@ -450,24 +477,20 @@ class CatalystTranspiler(AbstractTranspiler):
                         left_col = self._convert_chunk(params, left)
                         return self._lower_eq(params, left_col, comp, equal=False)
                     case ast.Lt():
-                        left_col = self._convert_chunk(params, left)
                         return self._lower_value_compare(
-                            params, left_col, comp, lambda l, r: l < r, "<"
+                            params, left, comp, lambda l, r: l < r, "<"
                         )
                     case ast.LtE():
-                        left_col = self._convert_chunk(params, left)
                         return self._lower_value_compare(
-                            params, left_col, comp, lambda l, r: l <= r, "<="
+                            params, left, comp, lambda l, r: l <= r, "<="
                         )
                     case ast.Gt():
-                        left_col = self._convert_chunk(params, left)
                         return self._lower_value_compare(
-                            params, left_col, comp, lambda l, r: l > r, ">"
+                            params, left, comp, lambda l, r: l > r, ">"
                         )
                     case ast.GtE():
-                        left_col = self._convert_chunk(params, left)
                         return self._lower_value_compare(
-                            params, left_col, comp, lambda l, r: l >= r, ">="
+                            params, left, comp, lambda l, r: l >= r, ">="
                         )
                     case _:
                         raise UnsupportedOperationException(
@@ -479,16 +502,19 @@ class CatalystTranspiler(AbstractTranspiler):
                 # the current input-type variant (see ``_category``): Python's
                 # `+` / `*` are overloaded for text. `+` -> add (num,num) or
                 # concat (str,str); `*` -> multiply (num,num) or repeat (str,int
-                # / int,str); `-` / `%` / `**` are numeric-only. Combos that
-                # don't fit (str+int, str-str, ...) raise so this variant is
-                # dropped and the JVM picks another option or falls back to the
-                # Python UDF.
+                # / int,str); `-` / `%` are numeric-only. Combos that don't fit
+                # (str+int, str-str, ...) raise so this variant is dropped and
+                # the JVM picks another option or falls back to the Python UDF.
+                #
+                # `**` is intentionally NOT lowered: Spark's `pow` is DOUBLE and
+                # loses precision for large integers, so it would silently return
+                # wrong results. TODO (SPARK-55210): add an exact integer-power
+                # lowering and re-enable it.
                 #
                 # Value-level divergences remain documented (need runtime value
                 # info, not type): overflow raises ARITHMETIC_OVERFLOW under ANSI
                 # where Python promotes to a big int; arithmetic is not
-                # NULL-guarded (`x + 1` on NULL -> NULL vs Python TypeError); and
-                # `**` -> Spark `pow` (DOUBLE) loses precision for large ints.
+                # NULL-guarded (`x + 1` on NULL -> NULL vs Python TypeError).
                 # TODO (SPARK-55210): map overflow / divide-by-zero precisely.
                 lc = self._category(params, left)
                 rc = self._category(params, right)
@@ -517,9 +543,6 @@ class CatalystTranspiler(AbstractTranspiler):
                             # abs(b))` reproduces Python for any non-zero divisor.
                             sb = sign(right_col)
                             return sb * pmod(sb * left_col, _abs(right_col))
-                    case ast.Pow():
-                        if lc == rc == "numeric":
-                            return left_col.__pow__(right_col)
                     case _:
                         raise UnsupportedOperationException(
                             f"binary operator {type(op).__name__} is not "
@@ -608,9 +631,15 @@ def _annotation_category(annotation: Optional[ast.AST]) -> Optional[str]:
         name = annotation.id
     elif isinstance(annotation, ast.Constant) and isinstance(annotation.value, str):
         name = annotation.value  # stringized annotation, e.g. def f(a: "int")
-    if name in ("str", "bytes"):
+    # Only str -> "string" and int/float -> "numeric". bool/complex/bytes are
+    # deliberately left unrecognised (-> None, "try both") so they fall back
+    # like any other unsupported type: bool/complex have no usable lowering
+    # (Spark can't do arithmetic on booleans and has no complex type) and bytes
+    # is BinaryType, which the string lowerings (concat/repeat) reject. This
+    # mirrors the constant handling in ``_category``.
+    if name == "str":
         return "string"
-    if name in ("int", "float", "complex", "bool"):
+    if name in ("int", "float"):
         return "numeric"
     return None
 

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -223,6 +223,12 @@ class CatalystTranspiler(AbstractTranspiler):
         operands (three-valued logic), which would round-trip through
         the UDF as ``None`` rather than the bool Python would have
         produced. Hand-roll the four cases via ``when`` branches.
+
+        Caveat: when the operands are different types Spark coerces before
+        comparing (e.g. an int column ``== "5"`` is True after casting the
+        string), whereas Python's ``==`` is False across unequal types. The
+        transpiler can't see column types, so this divergence is documented
+        rather than guarded.
         """
         right_col = self._convert_chunk(params, right_node)
         left_null = left_col.isNull()
@@ -259,6 +265,13 @@ class CatalystTranspiler(AbstractTranspiler):
         Callers that have already proven the operand non-null (``if x is
         not None: x > 0``) take the otherwise branch, so they never trip
         the raise.
+
+        Two value-level differences from Python remain (they need runtime
+        type/value info, so they are documented, not guarded): Spark orders
+        ``NaN`` as greater than every value, whereas Python's ``NaN``
+        comparisons are all ``False``; and operands of different types are
+        coerced by Spark (e.g. an int column ``> "5"``) where Python raises
+        ``TypeError``.
         """
         right_col = self._convert_chunk(params, right_node)
         null_guard = left_col.isNull() | right_col.isNull()
@@ -409,6 +422,24 @@ class CatalystTranspiler(AbstractTranspiler):
                             "is not supported by the transpiler"
                         )
             case ast.BinOp(left=left, op=op, right=right):
+                # The arithmetic operators below assume *numeric* operands.
+                # Python overloads `+` / `*` / `%` for str/bytes (text
+                # concatenation, repetition, %-formatting), which have no
+                # arithmetic meaning -- e.g. `a + "!"`, `"%d" % x`, `"ab" * n`.
+                # A string/bytes literal operand is therefore never arithmetic,
+                # so refuse it and fall back to interpreted Python. A string
+                # *column* operand can't be detected here (no schema info), so
+                # e.g. `a + 5` or `a * 3` on a string column still transpiles
+                # and diverges: a non-numeric value raises a Catalyst cast
+                # error, while a numeric-looking value is silently coerced
+                # (e.g. "2" * 3 -> 6, not "222"). Fixing that needs schema-aware
+                # transpilation; until then it is a documented limitation.
+                if _is_str_or_bytes_constant(left) or _is_str_or_bytes_constant(right):
+                    raise UnsupportedOperationException(
+                        "binary operator with a string/bytes literal operand "
+                        "(Python text concatenation / repetition / formatting) "
+                        "is not arithmetic and is not supported by the transpiler"
+                    )
                 left_col = self._convert_chunk(params, left)
                 if left_col is None:
                     raise UnsupportedOperationException(
@@ -420,8 +451,21 @@ class CatalystTranspiler(AbstractTranspiler):
                         "BinOp right operand could not be lowered to a Column"
                     )
                 match op:
-                    # TODO (SPARK-55210): Use try-variant functions to map Python exceptional
-                    # cases (e.g. overflow, divide-by-zero) to Catalyst errors more precisely.
+                    # These operators assume numeric operands and ANSI mode.
+                    # Known divergences from Python (they need runtime
+                    # type/value info the transpiler doesn't have, so they are
+                    # documented rather than guarded):
+                    #  * overflow -- under ANSI Spark raises ARITHMETIC_OVERFLOW
+                    #    where Python promotes to an arbitrary-precision int;
+                    #  * NULL -- arithmetic is NOT null-guarded (unlike the
+                    #    ordering comparisons above), so `x + 1` on a NULL input
+                    #    yields NULL whereas Python raises TypeError; guard with
+                    #    `is not None` for parity;
+                    #  * `**` lowers to Spark `pow`, which returns DOUBLE, so a
+                    #    large integer base/exponent can lose precision.
+                    # TODO (SPARK-55210): use try-variant functions to map Python
+                    # exceptional cases (overflow, divide-by-zero) to Catalyst
+                    # errors more precisely.
                     case ast.Add():
                         return left_col.__add__(right_col)
                     case ast.Sub():
@@ -513,6 +557,17 @@ def _get_transpilers(session: "SparkSession") -> List[AbstractTranspiler]:
         for name in transpiler_names
         if name in AbstractTranspiler.varieties
     ]
+
+
+def _is_str_or_bytes_constant(node: ast.AST) -> bool:
+    """True for a literal ``str`` / ``bytes`` operand.
+
+    Python overloads ``+`` / ``*`` / ``%`` for text (concatenation,
+    repetition, %-formatting); a string/bytes literal operand therefore never
+    denotes arithmetic, so the transpiler refuses such a ``BinOp`` and falls
+    back to interpreted Python rather than emit a numeric op over text.
+    """
+    return isinstance(node, ast.Constant) and isinstance(node.value, (str, bytes))
 
 
 def _get_src_ast_from_func(func: Callable) -> Tuple[Optional[str], Optional[ast.AST]]:

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -283,6 +283,46 @@ class CatalystTranspiler(AbstractTranspiler):
         )
         return when(null_guard, raise_error(err)).otherwise(op(left_col, right_col))
 
+    def _guard_numeric_binop(
+        self,
+        left: ast.AST,
+        left_col: Column,
+        right: ast.AST,
+        right_col: Column,
+        result: Column,
+        op_repr: str,
+    ) -> Column:
+        """Guard an arithmetic result against textual column operands at runtime.
+
+        The transpiler has no column types, and Python overloads ``+`` / ``*`` /
+        ``%`` for text (concatenation / repetition / %-formatting) while ``-`` /
+        ``**`` reject it; Spark would instead silently coerce a numeric-looking
+        string (``"2" * 3 -> 6``, not ``"222"``) or raise a cast error. A single
+        Catalyst expression can't return both the textual and numeric outcomes,
+        so for any operand that is not a numeric literal we check its runtime
+        type and raise loudly when it is string/binary. String/bytes *literals*
+        never reach here -- they force a fall back to interpreted Python earlier.
+        """
+        checks = [
+            typeof(col).isin("string", "binary")
+            for node, col in ((left, left_col), (right, right_col))
+            if not isinstance(node, ast.Constant)
+        ]
+        if not checks:
+            return result
+        textual = checks[0]
+        for extra in checks[1:]:
+            textual = textual | extra
+        err = raise_error(
+            lit(
+                f"Python UDF transpiler: `{op_repr}` requires numeric operands; "
+                "a string/bytes operand has no arithmetic meaning here (Python "
+                "would concatenate, repeat, format, or raise). Guard or rewrite "
+                "the UDF."
+            )
+        )
+        return when(textual, err).otherwise(result)
+
     def _convert_chunk(self, params: List[str], body: ast.AST | None) -> Column:
         match body:
             case None:
@@ -423,18 +463,17 @@ class CatalystTranspiler(AbstractTranspiler):
                             "is not supported by the transpiler"
                         )
             case ast.BinOp(left=left, op=op, right=right):
-                # The arithmetic operators below assume *numeric* operands.
-                # Python overloads `+` / `*` / `%` for str/bytes (text
-                # concatenation, repetition, %-formatting), which have no
-                # arithmetic meaning -- e.g. `a + "!"`, `"%d" % x`, `"ab" * n`.
-                # A string/bytes literal operand is therefore never arithmetic,
-                # so refuse it and fall back to interpreted Python. A string
-                # *column* operand can't be detected here (no schema info):
-                # `+` / `-` still transpile and diverge (Spark coerces a
-                # numeric-looking "10" + 5 -> 15, or raises a cast error), while
-                # `*` is guarded at runtime in the Mult case below to raise
-                # rather than silently coerce ("2" * 3). Fully resolving the
-                # column cases needs schema-aware transpilation.
+                # Arithmetic operators assume *numeric* operands, but Python
+                # overloads `+` / `*` / `%` for text (concatenation, repetition,
+                # %-formatting) and rejects `-` / `**` on text. Two layers guard
+                # this: (1) a string/bytes *literal* operand is statically
+                # detectable and forces a fall back to interpreted Python, so
+                # `a + "!"` or `"%d" % x` still runs correctly; (2) a non-literal
+                # operand's type is unknown at transpile time, so
+                # `_guard_numeric_binop` adds a runtime check that raises rather
+                # than let Spark silently coerce `"2" * 3 -> 6` or `"10" + 5 ->
+                # 15`. Fully correct text handling would need schema-aware
+                # transpilation; until then we fail loudly instead of wrong.
                 if _is_str_or_bytes_constant(left) or _is_str_or_bytes_constant(right):
                     raise UnsupportedOperationException(
                         "binary operator with a string/bytes literal operand "
@@ -452,67 +491,46 @@ class CatalystTranspiler(AbstractTranspiler):
                         "BinOp right operand could not be lowered to a Column"
                     )
                 match op:
-                    # These operators assume numeric operands and ANSI mode.
-                    # Known divergences from Python (they need runtime
-                    # type/value info the transpiler doesn't have, so they are
-                    # documented rather than guarded):
-                    #  * overflow -- under ANSI Spark raises ARITHMETIC_OVERFLOW
-                    #    where Python promotes to an arbitrary-precision int;
-                    #  * NULL -- arithmetic is NOT null-guarded (unlike the
-                    #    ordering comparisons above), so `x + 1` on a NULL input
-                    #    yields NULL whereas Python raises TypeError; guard with
-                    #    `is not None` for parity;
-                    #  * `**` lowers to Spark `pow`, which returns DOUBLE, so a
-                    #    large integer base/exponent can lose precision.
-                    # TODO (SPARK-55210): use try-variant functions to map Python
-                    # exceptional cases (overflow, divide-by-zero) to Catalyst
-                    # errors more precisely.
+                    # Value-level divergences remain documented (they need
+                    # runtime value info, not just type): overflow raises
+                    # ARITHMETIC_OVERFLOW under ANSI where Python promotes to a
+                    # big int; arithmetic is not NULL-guarded, so `x + 1` on a
+                    # NULL input yields NULL where Python raises TypeError; and
+                    # `**` lowers to Spark `pow` (DOUBLE), losing precision for
+                    # large integers (e.g. (2**27 + 1) ** 2 is off by one).
+                    # TODO (SPARK-55210): map overflow / divide-by-zero to
+                    # Catalyst errors via try-variant functions.
                     case ast.Add():
-                        return left_col.__add__(right_col)
-                    case ast.Sub():
-                        return left_col.__sub__(right_col)
-                    case ast.Mult():
-                        # Python's `*` repeats str/bytes (e.g. "ab" * 3 ->
-                        # "ababab"), and Spark would otherwise silently coerce a
-                        # numeric-looking string ("2" * 3 -> 6, not "222") -- a
-                        # silent wrong value. We can't see operand types at
-                        # transpile time, so guard at runtime: a single Catalyst
-                        # expression can't return both the string repetition and
-                        # the numeric product, so raise loudly rather than
-                        # miscompute when an operand is textual.
-                        textual = typeof(left_col).isin("string", "binary") | typeof(
-                            right_col
-                        ).isin("string", "binary")
-                        mult_err = raise_error(
-                            lit(
-                                "Python UDF transpiler: `*` requires numeric "
-                                "operands; Python's str/bytes repetition (e.g. "
-                                '"ab" * n) is not supported -- guard or rewrite '
-                                "the UDF."
-                            )
+                        return self._guard_numeric_binop(
+                            left, left_col, right, right_col, left_col.__add__(right_col), "+"
                         )
-                        return when(textual, mult_err).otherwise(left_col.__mul__(right_col))
+                    case ast.Sub():
+                        return self._guard_numeric_binop(
+                            left, left_col, right, right_col, left_col.__sub__(right_col), "-"
+                        )
+                    case ast.Mult():
+                        return self._guard_numeric_binop(
+                            left, left_col, right, right_col, left_col.__mul__(right_col), "*"
+                        )
                     case ast.Mod():
-                        # Python's `%` returns a result with the sign of the
-                        # divisor; Spark's `%` returns the sign of the
-                        # dividend, and Spark's `pmod` is documented for
-                        # non-negative divisors only. The composition
-                        # `sign(b) * pmod(sign(b) * a, abs(b))` reproduces
-                        # Python's semantics for any non-zero divisor without
-                        # us having to reach into Catalyst internals --
-                        # `pmod` does the unsigned remainder, `sign` and
-                        # `abs` line the inputs and output up with the
-                        # divisor's sign.
+                        # Python's `%` takes the sign of the divisor; Spark's
+                        # takes the dividend's. `sign(b) * pmod(sign(b) * a,
+                        # abs(b))` reproduces Python for any non-zero divisor.
                         sb = sign(right_col)
-                        return sb * pmod(sb * left_col, _abs(right_col))
+                        return self._guard_numeric_binop(
+                            left,
+                            left_col,
+                            right,
+                            right_col,
+                            sb * pmod(sb * left_col, _abs(right_col)),
+                            "%",
+                        )
                     case ast.Pow():
-                        # `**` lowers to Spark `pow`, which returns DOUBLE.
-                        # Beyond ~2**53 a double can't hold the result exactly,
-                        # so a large integer base/exponent loses precision
-                        # (e.g. (2**27 + 1) ** 2 is off by one) where Python
-                        # keeps arbitrary-precision ints. Documented limitation;
-                        # fixing it would need a dedicated integer-power path.
-                        return left_col.__pow__(right_col)
+                        # `**` lowers to Spark `pow` (DOUBLE); see the precision
+                        # note above.
+                        return self._guard_numeric_binop(
+                            left, left_col, right, right_col, left_col.__pow__(right_col), "**"
+                        )
                     case _:
                         raise UnsupportedOperationException(
                             f"binary operator {type(op).__name__} is not "

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -545,15 +545,16 @@ def _get_function_from_ast(body: ast.AST) -> ast.FunctionDef | None:
 
     Handles the following source patterns (in order):
 
-    * ``f = lambda x: x + 1``  — direct assignment
-    * ``f = some_wrapper(lambda x: x + 1, ...)``  — lambda as first positional
-      arg of a call (e.g. ``functools.partial``)
-    * ``lambda x: x + 1``  — bare expression (getsource on a raw lambda)
+    * ``f = lambda x: x + 1`` -- lambda bound directly to a name
+    * ``lambda x: x + 1`` -- bare expression (getsource on a raw lambda)
     * ``def f(x): ... return x + 1``
-    * class with callable
+    * a class with a ``__call__`` method
 
-    Returns ``None`` when no single unambiguous function can be identified.
-    Not yet handled: local class variables.
+    Returns ``None`` when no single unambiguous function can be identified --
+    notably, a lambda wrapped in a call such as
+    ``f = some_wrapper(lambda x: x + 1)`` parses as ``Assign(value=Call(...))``,
+    which is not unwrapped here and so falls back to interpreted Python. Local
+    class variables are likewise unsupported.
     """
     if not hasattr(body, "body") or not body.body:
         return None
@@ -617,6 +618,30 @@ def _transpile_func(
         function_ast = _get_function_from_ast(ast)
         if function_ast is None:
             return ([], ["Error extracting function body from ast, cannot transpile"], [])
+        # Default, variadic (``*args`` / ``**kwargs``), keyword-only, and
+        # positional-only parameters can't be represented by the positional
+        # ``_udf_param_N`` placeholder scheme: a call site may omit a
+        # defaulted argument, leaving the placeholder referencing a position
+        # the call never bound, and ``_get_parameter_list`` only reads
+        # ``args``. Fall back to interpreted Python rather than emit an
+        # invalid plan.
+        fn_args = function_ast.args
+        if (
+            fn_args.defaults
+            or any(d is not None for d in fn_args.kw_defaults)
+            or fn_args.kwonlyargs
+            or fn_args.vararg is not None
+            or fn_args.kwarg is not None
+            or getattr(fn_args, "posonlyargs", [])
+        ):
+            return (
+                [],
+                [
+                    "functions with default, variadic, keyword-only, or "
+                    "positional-only arguments are not supported by the transpiler"
+                ],
+                [],
+            )
         params = _get_parameter_list(function_ast)
         # Strip ``self`` for the caller-facing param list -- callers will
         # match user-supplied kwargs against this, and the user doesn't

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -41,6 +41,7 @@ from pyspark.sql.functions import (
     pmod,
     raise_error,
     sign,
+    typeof,
     when,
 )
 
@@ -428,12 +429,12 @@ class CatalystTranspiler(AbstractTranspiler):
                 # arithmetic meaning -- e.g. `a + "!"`, `"%d" % x`, `"ab" * n`.
                 # A string/bytes literal operand is therefore never arithmetic,
                 # so refuse it and fall back to interpreted Python. A string
-                # *column* operand can't be detected here (no schema info), so
-                # e.g. `a + 5` or `a * 3` on a string column still transpiles
-                # and diverges: a non-numeric value raises a Catalyst cast
-                # error, while a numeric-looking value is silently coerced
-                # (e.g. "2" * 3 -> 6, not "222"). Fixing that needs schema-aware
-                # transpilation; until then it is a documented limitation.
+                # *column* operand can't be detected here (no schema info):
+                # `+` / `-` still transpile and diverge (Spark coerces a
+                # numeric-looking "10" + 5 -> 15, or raises a cast error), while
+                # `*` is guarded at runtime in the Mult case below to raise
+                # rather than silently coerce ("2" * 3). Fully resolving the
+                # column cases needs schema-aware transpilation.
                 if _is_str_or_bytes_constant(left) or _is_str_or_bytes_constant(right):
                     raise UnsupportedOperationException(
                         "binary operator with a string/bytes literal operand "
@@ -471,7 +472,26 @@ class CatalystTranspiler(AbstractTranspiler):
                     case ast.Sub():
                         return left_col.__sub__(right_col)
                     case ast.Mult():
-                        return left_col.__mul__(right_col)
+                        # Python's `*` repeats str/bytes (e.g. "ab" * 3 ->
+                        # "ababab"), and Spark would otherwise silently coerce a
+                        # numeric-looking string ("2" * 3 -> 6, not "222") -- a
+                        # silent wrong value. We can't see operand types at
+                        # transpile time, so guard at runtime: a single Catalyst
+                        # expression can't return both the string repetition and
+                        # the numeric product, so raise loudly rather than
+                        # miscompute when an operand is textual.
+                        textual = typeof(left_col).isin("string", "binary") | typeof(
+                            right_col
+                        ).isin("string", "binary")
+                        mult_err = raise_error(
+                            lit(
+                                "Python UDF transpiler: `*` requires numeric "
+                                "operands; Python's str/bytes repetition (e.g. "
+                                '"ab" * n) is not supported -- guard or rewrite '
+                                "the UDF."
+                            )
+                        )
+                        return when(textual, mult_err).otherwise(left_col.__mul__(right_col))
                     case ast.Mod():
                         # Python's `%` returns a result with the sign of the
                         # divisor; Spark's `%` returns the sign of the
@@ -486,6 +506,12 @@ class CatalystTranspiler(AbstractTranspiler):
                         sb = sign(right_col)
                         return sb * pmod(sb * left_col, _abs(right_col))
                     case ast.Pow():
+                        # `**` lowers to Spark `pow`, which returns DOUBLE.
+                        # Beyond ~2**53 a double can't hold the result exactly,
+                        # so a large integer base/exponent loses precision
+                        # (e.g. (2**27 + 1) ** 2 is off by one) where Python
+                        # keeps arbitrary-precision ints. Documented limitation;
+                        # fixing it would need a dedicated integer-power path.
                         return left_col.__pow__(right_col)
                     case _:
                         raise UnsupportedOperationException(

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -220,15 +220,14 @@ class UserDefinedFunction:
         from pyspark.sql import SparkSession
 
         session = SparkSession._instantiatedSession
+        # A nondeterministic UDF must not be transpiled: replacing it with a plain
+        # Catalyst expression would let the optimizer fold/reorder/duplicate it,
+        # discarding the nondeterminism barrier. (asNondeterministic() also clears
+        # any options set here, for the udf(f).asNondeterministic() ordering.)
         transpile_enabled = (
             False
             if session is None
             else (
-                # A nondeterministic UDF must not be transpiled: replacing it
-                # with a plain Catalyst expression would let the optimizer
-                # fold/reorder/duplicate it, discarding the nondeterminism
-                # barrier. (asNondeterministic() also clears any options set
-                # here, for the udf(f).asNondeterministic() ordering.)
                 deterministic
                 and evalType == PythonEvalType.SQL_BATCHED_UDF
                 and session.conf.get("spark.sql.experimental.optimizer.transpilePyUDFs") == "true"

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -224,7 +224,13 @@ class UserDefinedFunction:
             False
             if session is None
             else (
-                evalType == PythonEvalType.SQL_BATCHED_UDF
+                # A nondeterministic UDF must not be transpiled: replacing it
+                # with a plain Catalyst expression would let the optimizer
+                # fold/reorder/duplicate it, discarding the nondeterminism
+                # barrier. (asNondeterministic() also clears any options set
+                # here, for the udf(f).asNondeterministic() ordering.)
+                deterministic
+                and evalType == PythonEvalType.SQL_BATCHED_UDF
                 and session.conf.get("spark.sql.experimental.optimizer.transpilePyUDFs") == "true"
             )
         )
@@ -658,6 +664,14 @@ class UserDefinedFunction:
         # with 'deterministic' updated. See SPARK-23233.
         self._judf_placeholder = None
         self.deterministic = False
+        # A transpiled rewrite replaces the (now nondeterministic) Python UDF
+        # with a plain Catalyst expression, which the optimizer is free to
+        # fold, reorder, or duplicate -- discarding the nondeterminism barrier
+        # the caller just asked for. Drop any transpiled options so a
+        # nondeterministic UDF always runs as interpreted Python.
+        self.transpiled = []
+        self._transpiled_param_names = []
+        self._transpiled_input_categories = []
         return self
 
 

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -209,6 +209,10 @@ class UserDefinedFunction:
         # Extract Python UDF details if transpilation is enabled.
         self.transpiled: list = []
         self._transpiled_param_names: list[str] = []
+        # Per-option input-type categories ("numeric"/"string" per public param),
+        # parallel to ``self.transpiled``; the JVM picks the option matching the
+        # actual column types or falls back to interpreted Python.
+        self._transpiled_input_categories: list = []
         # When we have a transpiled rewrite, ``__call__`` resolves any
         # user-supplied kwargs against this positional parameter list so
         # the JVM-side ``_udf_param_N`` substitution sees the inputs in
@@ -250,9 +254,12 @@ class UserDefinedFunction:
             from pyspark.sql.transpile import _transpile_func
 
             try:
-                self.transpiled, errors, self._transpiled_param_names = _transpile_func(
-                    session, func, returnType
-                )
+                (
+                    self.transpiled,
+                    errors,
+                    self._transpiled_param_names,
+                    self._transpiled_input_categories,
+                ) = _transpile_func(session, func, returnType)
                 self._transpile_errors.extend(errors)
                 if not self.transpiled:
                     detail = f": {errors}" if errors else ""
@@ -489,6 +496,7 @@ class UserDefinedFunction:
             self.evalType,
             self.deterministic,
             map(_to_java_column_opt, self.transpiled),
+            self._transpiled_input_categories,
         )
         return judf
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/Analyzer.scala
@@ -575,7 +575,8 @@ class Analyzer(
       typeCoercionRules() ++
       Seq(
         ResolveWithCTE,
-        ExtractDistributedSequenceID) ++
+        ExtractDistributedSequenceID,
+        ResolveTranspiledPythonUDFOptions) ++
       Seq(ResolveUpdateEventTimeWatermarkColumn) ++
       extendedResolutionRules ++
       Seq(NameStreamingSources) : _*),

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.TranspiledPythonUDF
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.TRANSPILED_PYTHON_UDF
-import org.apache.spark.sql.types.{DataType, NumericType, StringType}
+import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, NumericType, StringType}
 
 /**
  * Prunes the per-input-type options carried by a [[TranspiledPythonUDF]] down to those whose
@@ -63,10 +63,12 @@ object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
     }
   }
 
-  // True when each declared category ("numeric"/"string") matches the corresponding argument type.
-  // Empty categories means "no restriction", so the option is kept. "string" matches only
-  // StringType -- not BinaryType -- because the string lowerings (e.g. `repeat`) require a string
-  // input; binary columns safely fall back to the Python UDF instead.
+  // True when each declared category matches the corresponding argument type:
+  // "numeric" -> NumericType, "string" -> StringType, "bool" -> BooleanType,
+  // "binary" -> BinaryType. "string" matches only StringType (not BinaryType): a
+  // bytes/BinaryType column is tagged "binary" instead, so the string lowerings
+  // (e.g. `repeat`) never see it. Empty categories means "no restriction", so the
+  // option is kept.
   private def optionMatchesTypes(categories: Seq[String], argTypes: Seq[DataType]): Boolean = {
     if (categories.isEmpty) {
       true
@@ -76,6 +78,8 @@ object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
       categories.zip(argTypes).forall {
         case ("numeric", dt) => dt.isInstanceOf[NumericType]
         case ("string", dt) => dt.isInstanceOf[StringType]
+        case ("bool", dt) => dt.isInstanceOf[BooleanType]
+        case ("binary", dt) => dt.isInstanceOf[BinaryType]
         case _ => false
       }
     }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.catalyst.expressions.TranspiledPythonUDF
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreePattern.TRANSPILED_PYTHON_UDF
+import org.apache.spark.sql.types.{DataType, NumericType, StringType}
+
+/**
+ * Prunes the per-input-type options carried by a [[TranspiledPythonUDF]] down to those whose
+ * declared categories match the resolved argument types.
+ *
+ * A Python operator such as `a + b` is overloaded for text, so the transpiler emits one option
+ * per input-type variant -- a numeric `Add` and a string `concat`, say -- each tagged with the
+ * input-type categories it expects. Those options are children of the node, so leaving a
+ * type-incompatible one in place (a numeric `Add` over string columns) would make `CheckAnalysis`
+ * reject the whole plan. We can only choose once the argument types are known, which is after
+ * reference resolution -- hence a rule here rather than in the builder, which runs at
+ * call-construction time before the columns are bound -- and we must run before `CheckAnalysis`.
+ *
+ * Matching is strict by category (a numeric option only for numeric columns, a string option only
+ * for string columns). We deliberately do not lean on implicit type coercion, which would, e.g.,
+ * make a numeric `Add` "valid" over a string column and silently diverge from Python's
+ * `TypeError`. When no option matches, the list is emptied and `ConvertToCatalyst` falls back to
+ * the original Python UDF.
+ */
+object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
+  def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!plan.containsPattern(TRANSPILED_PYTHON_UDF)) {
+      plan
+    } else {
+      plan.resolveOperatorsWithPruning(_.containsPattern(TRANSPILED_PYTHON_UDF)) {
+        case op if op.containsPattern(TRANSPILED_PYTHON_UDF) =>
+          // Bottom-up so a nested TranspiledPythonUDF (a transpiled UDF feeding another) is pruned
+          // -- and thus resolved -- before its parent's input types are inspected.
+          op.transformExpressionsUpWithPruning(_.containsPattern(TRANSPILED_PYTHON_UDF)) {
+            case t: TranspiledPythonUDF
+                if t.optionInputCategories.nonEmpty && t.pythonUDFExpr.childrenResolved =>
+              val argTypes = t.pythonUDFExpr.children.map(_.dataType)
+              val kept = t.transpiledOptions.zip(t.optionInputCategories).collect {
+                case (option, categories) if optionMatchesTypes(categories, argTypes) => option
+              }
+              t.copy(transpiledOptions = kept, optionInputCategories = Nil)
+          }
+      }
+    }
+  }
+
+  // True when each declared category ("numeric"/"string") matches the corresponding argument type.
+  // Empty categories means "no restriction", so the option is kept. "string" matches only
+  // StringType -- not BinaryType -- because the string lowerings (e.g. `repeat`) require a string
+  // input; binary columns safely fall back to the Python UDF instead.
+  private def optionMatchesTypes(categories: Seq[String], argTypes: Seq[DataType]): Boolean = {
+    if (categories.isEmpty) {
+      true
+    } else if (categories.length != argTypes.length) {
+      false
+    } else {
+      categories.zip(argTypes).forall {
+        case ("numeric", dt) => dt.isInstanceOf[NumericType]
+        case ("string", dt) => dt.isInstanceOf[StringType]
+        case _ => false
+      }
+    }
+  }
+}

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -96,7 +96,14 @@ trait PythonFuncExpression extends NonSQLExpression with UserDefinedExpression
 case class TranspiledPythonUDF(
   name: String,
   pythonUDFExpr: Expression,
-  transpiledOptions: List[Expression]) extends Expression with Unevaluable {
+  transpiledOptions: List[Expression],
+  // Per-option input-type categories ("numeric"/"string" per public param),
+  // parallel to `transpiledOptions`. ResolveTranspiledPythonUDFOptions prunes the
+  // options to those whose categories match the resolved input types (before
+  // CheckAnalysis can reject a type-incompatible option) and clears this field;
+  // ConvertToCatalyst then picks the first survivor or falls back to the Python
+  // UDF. Empty means "no restriction" (kept as-is).
+  optionInputCategories: List[List[String]] = Nil) extends Expression with Unevaluable {
   override def children: Seq[Expression] = pythonUDFExpr +: transpiledOptions
   override def dataType: DataType = pythonUDFExpr.dataType
   override def nullable: Boolean = pythonUDFExpr.nullable

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1029,10 +1029,13 @@ object ConvertToCatalyst extends Rule[LogicalPlan] {
             log"is disabled but we still got TranspiledPythonUDFs in our plan.")
           s.pythonUDFExpr.mapChildren(applyExpr(_, parentIsUdf = true))
         } else if (!parentIsUdf || !s.hasOnlyPythonUDFInputs) {
-          // Walk the full list of transpiled options and pick the first one
-          // that's actually usable, falling back to the original Python UDF
-          // if nothing fits. If you're plugging in your own transpilation, please add a
-          // separate ConvertToX so you can choose your desired transpiled nodes.
+          // Walk the full list of transpiled options and pick the first non-null
+          // one, falling back to the original Python UDF if none are available.
+          // Options whose declared input-type categories don't match the bound
+          // column types are already pruned during analysis by
+          // ResolveTranspiledPythonUDFOptions, so any option that reaches here is
+          // safe to use. If you're plugging in your own transpilation, please add
+          // a separate ConvertToX so you can choose your desired transpiled nodes.
           val firstEvaluable = s.transpiledOptions.find(expr => expr != null)
           firstEvaluable match {
             case None =>

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -303,6 +303,10 @@ abstract class Optimizer(catalogManager: CatalogManager)
    */
   def nonExcludableRules: Seq[String] =
     Seq(
+      // ConvertToCatalyst is the only rule that strips the Unevaluable
+      // TranspiledPythonUDF node; excluding it would leak that node into
+      // execution, so it must never be excludable.
+      ConvertToCatalyst.ruleName,
       FinishAnalysis.ruleName,
       RewriteDistinctAggregates.ruleName,
       ReplaceDeduplicateWithAggregate.ruleName,
@@ -1036,6 +1040,11 @@ object ConvertToCatalyst extends Rule[LogicalPlan] {
           // ResolveTranspiledPythonUDFOptions, so any option that reaches here is
           // safe to use. If you're plugging in your own transpilation, please add
           // a separate ConvertToX so you can choose your desired transpiled nodes.
+          // NOTE: the substituted option is used as-is, with no cast back to the
+          // UDF's declared return type. The built-in transpiler guarantees each
+          // option's dataType already matches; a custom transpiler MUST do the
+          // same (or insert its own Cast), or it will silently change the output
+          // schema.
           val firstEvaluable = s.transpiledOptions.find(expr => expr != null)
           firstEvaluable match {
             case None =>

--- a/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptionsSuite.scala
+++ b/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptionsSuite.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.api.python.PythonEvalType
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, Concat, Expression, Literal, PythonUDF, TranspiledPythonUDF}
+import org.apache.spark.sql.catalyst.plans.PlanTest
+import org.apache.spark.sql.catalyst.plans.logical.{LocalRelation, Project}
+import org.apache.spark.sql.types.LongType
+
+/**
+ * Unit tests for [[ResolveTranspiledPythonUDFOptions]], which prunes a
+ * TranspiledPythonUDF's per-input-type options to those whose declared categories match the
+ * resolved argument types. func=null in the leaf PythonUDF is intentional: these structural
+ * tests don't execute Python.
+ */
+class ResolveTranspiledPythonUDFOptionsSuite extends PlanTest {
+
+  private def pyUDF(children: Seq[Expression]): PythonUDF =
+    PythonUDF("udf", null, LongType, children,
+      PythonEvalType.SQL_BATCHED_UDF, udfDeterministic = true)
+
+  // Runs the rule on a Project that wraps the node, and returns the (possibly pruned) node.
+  private def prune(node: TranspiledPythonUDF, rel: LocalRelation): TranspiledPythonUDF = {
+    val rewritten = ResolveTranspiledPythonUDFOptions(Project(Seq(Alias(node, "r")()), rel))
+    rewritten.expressions.flatMap(_.collect { case t: TranspiledPythonUDF => t }).head
+  }
+
+  test("keeps the numeric option for numeric columns and drops the string one") {
+    val a = $"a".long
+    val b = $"b".long
+    val numericOpt = Add(a, b)
+    val stringOpt = Concat(Seq(a, b))
+    val node = TranspiledPythonUDF("udf", pyUDF(Seq(a, b)), List(numericOpt, stringOpt),
+      List(List("numeric", "numeric"), List("string", "string")))
+    val pruned = prune(node, LocalRelation(a, b))
+    assert(pruned.transpiledOptions == List(numericOpt))
+    assert(pruned.optionInputCategories.isEmpty)
+  }
+
+  test("keeps the string option for string columns and drops the numeric one") {
+    val a = $"a".string
+    val b = $"b".string
+    val numericOpt = Add(a, b)
+    val stringOpt = Concat(Seq(a, b))
+    val node = TranspiledPythonUDF("udf", pyUDF(Seq(a, b)), List(numericOpt, stringOpt),
+      List(List("numeric", "numeric"), List("string", "string")))
+    val pruned = prune(node, LocalRelation(a, b))
+    assert(pruned.transpiledOptions == List(stringOpt))
+    assert(pruned.optionInputCategories.isEmpty)
+  }
+
+  test("empties the options when no category set matches (falls back to Python UDF)") {
+    val a = $"a".string
+    val b = $"b".long
+    val node = TranspiledPythonUDF("udf", pyUDF(Seq(a, b)),
+      List(Add(a, b), Concat(Seq(a, b))),
+      List(List("numeric", "numeric"), List("string", "string")))
+    val pruned = prune(node, LocalRelation(a, b))
+    assert(pruned.transpiledOptions.isEmpty)
+    assert(pruned.optionInputCategories.isEmpty)
+  }
+
+  test("matches binary columns against neither category (string is StringType only)") {
+    val a = $"a".binary
+    val node = TranspiledPythonUDF("udf", pyUDF(Seq(a)),
+      List(Concat(Seq(a, a))), List(List("string")))
+    val pruned = prune(node, LocalRelation(a))
+    assert(pruned.transpiledOptions.isEmpty)
+  }
+
+  test("leaves options untouched when categories are empty (no restriction)") {
+    val a = $"a".long
+    val onlyOpt = Add(a, Literal(1L))
+    val node = TranspiledPythonUDF("udf", pyUDF(Seq(a)), List(onlyOpt), Nil)
+    val pruned = prune(node, LocalRelation(a))
+    assert(pruned.transpiledOptions == List(onlyOpt))
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -51,9 +51,11 @@ case class UserDefinedPythonFunction(
     // TODO: Add support for transpilation with Spark Connect and remove the default value.
     transpiled: JList[Column] = Nil.asJava,
     // Per-option input-type categories ("numeric"/"string" per public param),
-    // parallel to `transpiled`. `builder` keeps only the options whose categories
-    // match the bound argument types, so a later option can be picked or, when
-    // none match, the call falls back to the plain Python UDF.
+    // parallel to `transpiled` (same length). The analyzer rule
+    // ResolveTranspiledPythonUDFOptions later keeps only the options whose
+    // categories match the bound argument types; when none match, the call
+    // falls back to the plain Python UDF. `builder` requires the two lists to
+    // be parallel and skips transpilation otherwise.
     transpiledInputTypes: JList[JList[String]] = Nil.asJava) {
 
   def builder(e: Seq[Expression]): Expression = {
@@ -108,7 +110,14 @@ case class UserDefinedPythonFunction(
     // bound, so their types aren't known yet. ResolveTranspiledPythonUDFOptions
     // prunes the options to those matching the resolved input types (once known,
     // and before CheckAnalysis), and ConvertToCatalyst picks the survivor.
-    if (transpiledExprsForUse.nonEmpty) {
+    // Only build the node when every option carries its parallel input-type
+    // categories. ResolveTranspiledPythonUDFOptions prunes type-incompatible
+    // options using those categories, but only when they are present (its guard
+    // is `optionInputCategories.nonEmpty`); an empty or mismatched categories
+    // list would leave a type-invalid option to fail CheckAnalysis instead of
+    // falling back. If the two lists don't line up, skip transpilation.
+    if (transpiledExprsForUse.nonEmpty &&
+        optionInputTypesForUse.length == transpiledExprsForUse.length) {
       val tpu =
         TranspiledPythonUDF(name, udfExpr, transpiledExprsForUse, optionInputTypesForUse)
       // Resolve the UDF parameters to match the original UDF children

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -49,7 +49,12 @@ case class UserDefinedPythonFunction(
     pythonEvalType: Int,
     udfDeterministic: Boolean,
     // TODO: Add support for transpilation with Spark Connect and remove the default value.
-    transpiled: JList[Column] = Nil.asJava) {
+    transpiled: JList[Column] = Nil.asJava,
+    // Per-option input-type categories ("numeric"/"string" per public param),
+    // parallel to `transpiled`. `builder` keeps only the options whose categories
+    // match the bound argument types, so a later option can be picked or, when
+    // none match, the call falls back to the plain Python UDF.
+    transpiledInputTypes: JList[JList[String]] = Nil.asJava) {
 
   def builder(e: Seq[Expression]): Expression = {
     if (pythonEvalType == PythonEvalType.SQL_BATCHED_UDF
@@ -71,6 +76,8 @@ case class UserDefinedPythonFunction(
     }
     val transpiledExprs: List[Expression] = transpiled.asScala.map(
       column => ColumnConversions.expression(column)).toList
+    val optionInputTypes: List[List[String]] =
+      transpiledInputTypes.asScala.map(_.asScala.toList).toList
 
 
     val udfExpr = if (pythonEvalType == PythonEvalType.SQL_GROUPED_AGG_PANDAS_UDF
@@ -93,9 +100,17 @@ case class UserDefinedPythonFunction(
     // path execute.
     val transpiledExprsForUse =
       if (e.exists(_.isInstanceOf[NamedArgumentExpression])) Nil else transpiledExprs
-    // If we have a possible transpiled expression insert that node so we can choose later
+    val optionInputTypesForUse =
+      if (e.exists(_.isInstanceOf[NamedArgumentExpression])) Nil else optionInputTypes
+    // If we have possible transpiled expressions insert the node carrying every
+    // option plus its declared input-type categories. We can't pick here: this
+    // builder runs at call-construction time, before the argument columns are
+    // bound, so their types aren't known yet. ResolveTranspiledPythonUDFOptions
+    // prunes the options to those matching the resolved input types (once known,
+    // and before CheckAnalysis), and ConvertToCatalyst picks the survivor.
     if (transpiledExprsForUse.nonEmpty) {
-      val tpu = TranspiledPythonUDF(name, udfExpr, transpiledExprsForUse)
+      val tpu =
+        TranspiledPythonUDF(name, udfExpr, transpiledExprsForUse, optionInputTypesForUse)
       // Resolve the UDF parameters to match the original UDF children
       def resolveUDFParams(expression: Expression, children: Array[Expression]): Expression = {
         expression match {
@@ -133,8 +148,8 @@ case class UserDefinedPythonFunction(
    */
   def fromUDFExpr(expr: Expression): Column = {
     Column(expr match {
-      case TranspiledPythonUDF(name, udaf: PythonUDAF, transpiled) =>
-        TranspiledPythonUDF(name, udaf.toAggregateExpression(), transpiled)
+      case TranspiledPythonUDF(name, udaf: PythonUDAF, transpiled, inputCategories) =>
+        TranspiledPythonUDF(name, udaf.toAggregateExpression(), transpiled, inputCategories)
       case udaf: PythonUDAF => udaf.toAggregateExpression()
       case _ => expr
     })


### PR DESCRIPTION
## Summary

This PR adds extensive test coverage for Python UDF transpilation to Catalyst expressions and implements handling for several edge cases and known divergences from Python semantics.

## Key Changes

### Test Coverage (`test_udf_transpile_unit.py`)
- **`test_udf_transpile_lowers_operators`**: Validates that operators (arithmetic, comparison, boolean, string) correctly lower to Catalyst and match Python semantics for modulo sign-parity, non-commutative operations, exponentiation, unary nesting, constant bodies, and if/elif/else control flow.
- **`test_udf_transpile_callable_object_self_offset`**: Verifies that callable instances correctly offset `self` so parameters map to `_udf_param_N` placeholders.
- **`test_udf_transpile_plan_elision`**: Confirms that transpiled UDFs are elided from the execution plan in filters and selects, and that mixed chains of convertible/non-convertible UDFs inline only the convertible ones.
- **`test_udf_transpile_config_toggle_no_stale_nodes`**: Ensures UDFs built with transpilation enabled fall back cleanly to interpreted Python when executed with the flags disabled.
- **`test_udf_transpile_casts_to_return_type`**: Validates that lowered expressions are cast to the declared return type.
- **`test_udf_transpile_falls_back`**: Confirms fallback to interpreted Python for unsupported patterns: inline/wrapped/partial lambdas, default/variadic/keyword-only arguments, and string-literal operator overloading.
- **`test_udf_transpile_known_value_divergences`**: Documents and pins expected divergences from Python (NULL arithmetic, NaN ordering, type coercion) that require runtime type/value info to fix.
- **`test_udf_transpile_known_raise_divergences`**: Documents and pins expected exceptions that differ from Python (overflow under ANSI, modulo by zero, string multiplication type guards).
- **`test_udf_transpile_power_precision_divergence`**: Documents precision loss in `**` operator due to conversion to DOUBLE.

### Transpiler Implementation (`transpile.py`)
- **String/bytes literal detection**: Added `_is_str_or_bytes_constant()` to detect and reject binary operations with string/bytes literals (Python text concatenation, repetition, %-formatting), falling back to interpreted Python.
- **Multiplication guard**: Implemented runtime type checking for `*` operator to raise an error when operands are textual, preventing silent coercion (e.g., `"2" * 3` would incorrectly yield 6 instead of "222").
- **Parameter validation**: Added checks to reject functions with default arguments, variadic parameters (`*args`, `**kwargs`), keyword-only arguments, or positional-only arguments, which cannot be represented by the positional `_udf_param_N` scheme.
- **Documentation**: Enhanced docstrings in `_lower_eq()`, `_lower_value_compare()`, and arithmetic operator cases to document known divergences and limitations (overflow, NULL handling, NaN ordering, type coercion, precision loss).

### Parity Tests (`test_udf_transpile_parity.py`)
- New test file that re-runs existing UDF test suites (`BaseUDFTestsMixin`, `UDFCombinationsTestsMixin`, `UnifiedUDFTestsMixin`) with transpilation enabled to verify that enabling the experimental feature does not change UDF results compared to the default (transpilation off) runs.
- Three concrete test classes: `TranspiledUDFParityTests`, `TranspiledUDFCombinationsParityTests`, `TranspiledUnifiedUDFParityTests`.

### Configuration
- Added `_TRANSPILE_ON` constant in unit tests defining the two required flags: `spark.sql.experimental.optimizer.transpilePyUDFs` and `spark.sql.ansi.enabled`.

## Notable Implementation Details

1. **Fallback Strategy**: The transpiler is designed to fall back to interpreted Python rather than

https://claude.ai/code/session_013GD7N69Zz5FaRiuMQc9d5P