### PR TITLE
Upgrade Scala 2.13 to 2.13.11 for JDK 21 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3698,7 +3698,12 @@
     <profile>
       <id>scala-2.13</id>
       <properties>
-        <scala.version>2.13.8</scala.version>
+        <!-- SPARK-CVE: 2.13.8 -> 2.13.11. Scala 2.13.8's classfile parser crashes with
+             "bad constant pool index" reading the JDK 21-built commons-lang3 3.18.0 classes
+             (the JavaVersion enum) pulled in for CVE-2025-48924. 2.13.11 is the minimal patch
+             that reads JDK 21 class files; genjavadoc-plugin_2.13.11 (0.18) is published, so no
+             genjavadoc bump is needed. The 2.12 build is unaffected (2.12.18 reads lang3 3.18.0). -->
+        <scala.version>2.13.11</scala.version>
         <scala.binary.version>2.13</scala.binary.version>
       </properties>
       <build>
@@ -3751,6 +3756,14 @@
                   <arg>-Wconf:cat=unchecked&amp;msg=outer reference:s</arg>
                   <arg>-Wconf:cat=unchecked&amp;msg=eliminated by erasure:s</arg>
                   <arg>-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s</arg>
+                  <!--
+                    SPARK-CVE: the Scala 2.13.8 -> 2.13.11 bump (see scala-2.13 profile properties)
+                    newly emits "Implicit definition should have explicit type", which the
+                    fatal-warnings config above turns into errors. Spark 3.5 source predates
+                    explicit-typing these implicits (done upstream for Scala 2.13.16 / Spark 4.0),
+                    so mute the warning here. Keep in sync with project/SparkBuild.scala.
+                  -->
+                  <arg>-Wconf:msg=Implicit definition should have explicit type:s</arg>
                   <!--
                     TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
                     from the corresponding files when Scala 2.12 is no longer supported.

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -288,6 +288,13 @@ object SparkBuild extends PomBuild {
           "-Wconf:cat=unchecked&msg=outer reference:s",
           "-Wconf:cat=unchecked&msg=eliminated by erasure:s",
           "-Wconf:msg=^(?=.*?a value of type)(?=.*?cannot also be).+$:s",
+          // SPARK-CVE: the Scala 2.13.8 -> 2.13.11 bump (so scalac can read the JDK 21-built
+          // commons-lang3 3.18.0 class files / JavaVersion enum for CVE-2025-48924; 2.13.8 crashes
+          // with "bad constant pool index") newly emits "Implicit definition should have explicit
+          // type", which the fatal-warnings config above turns into errors. Spark 3.5 source
+          // predates explicit-typing these implicits (done upstream for Scala 2.13.16 / Spark 4.0),
+          // so mute the warning here. Keep in sync with the scala-2.13 profile in pom.xml.
+          "-Wconf:msg=Implicit definition should have explicit type:s",
           // TODO(SPARK-43850): Remove the following suppression rules and remove `import scala.language.higherKinds`
           // from the corresponding files when Scala 2.12 is no longer supported.
           "-Wconf:cat=unused-imports&src=org\\/apache\\/spark\\/graphx\\/impl\\/VertexPartitionBase.scala:s",


### PR DESCRIPTION
## Summary
Upgrades the Scala 2.13 compiler version from 2.13.8 to 2.13.11 to resolve a classfile parsing issue that prevents reading JDK 21-built commons-lang3 3.18.0 classes (required for CVE-2025-48924). Scala 2.13.8 crashes with "bad constant pool index" when encountering JDK 21 class files, while 2.13.11 is the minimal patch version that supports reading them.

## Key Changes
- **pom.xml**: Updated `scala.version` property in the `scala-2.13` profile from 2.13.8 to 2.13.11
- **pom.xml**: Added compiler warning suppression for "Implicit definition should have explicit type" in the Scala 2.13 compiler configuration, as this warning is newly emitted by 2.13.11 and would be treated as an error due to fatal-warnings configuration
- **project/SparkBuild.scala**: Added the same compiler warning suppression to keep the SBT build configuration in sync with Maven

## Implementation Details
- The Scala 2.13.11 upgrade is necessary to support reading commons-lang3 3.18.0 (which contains the JavaVersion enum built with JDK 21)
- Scala 2.12.18 is unaffected and continues to read lang3 3.18.0 without issues
- The new "Implicit definition should have explicit type" warnings are suppressed rather than fixed, as Spark 3.5 source predates explicit typing of implicits (which is done upstream for Scala 2.13.16 / Spark 4.0)
- No genjavadoc plugin bump is needed, as genjavadoc-plugin_2.13.11 (0.18) is already published
- Both pom.xml and project/SparkBuild.scala are kept in sync with matching comments explaining the rationale

https://claude.ai/code/session_0139pFCYEy7rrrjbG3MzDfpb