### PR TITLE
Fix sbt dependency resolution issues with Maven-populated ~/.m2

### DIFF
--- a/dev/mima
+++ b/dev/mima
@@ -25,8 +25,33 @@ FWDIR="$(cd "`dirname "$0"`"/..; pwd)"
 cd "$FWDIR"
 
 SPARK_PROFILES=${1:-"-Pmesos -Pkubernetes -Pyarn -Pspark-ganglia-lgpl -Pkinesis-asl -Phive-thriftserver -Phive"}
-TOOLS_CLASSPATH="$(build/sbt -DcopyDependencies=false "export tools/fullClasspath" | grep jar | tail -n1)"
-OLD_DEPS_CLASSPATH="$(build/sbt -DcopyDependencies=false $SPARK_PROFILES "export oldDeps/fullClasspath" | grep jar | tail -n1)"
+
+# Run an sbt "export <project>/fullClasspath" command and print the exported classpath.
+# The sbt output is only consumed through a command substitution below, so without extra
+# care any sbt failure would abort the script (set -e) with the error message captured
+# and never shown. Buffer the output in a temp file and dump it on failure instead.
+export_classpath() {
+  local sbt_output classpath
+  sbt_output="$(mktemp)"
+  if ! build/sbt -DcopyDependencies=false "$@" > "$sbt_output" 2>&1; then
+    echo "ERROR: sbt failed while running: build/sbt -DcopyDependencies=false $*" >&2
+    cat "$sbt_output" >&2
+    rm -f "$sbt_output"
+    return 1
+  fi
+  classpath="$(grep jar "$sbt_output" | tail -n1)"
+  if [ -z "$classpath" ]; then
+    echo "ERROR: no classpath found in sbt output of: build/sbt -DcopyDependencies=false $*" >&2
+    cat "$sbt_output" >&2
+    rm -f "$sbt_output"
+    return 1
+  fi
+  rm -f "$sbt_output"
+  echo "$classpath"
+}
+
+TOOLS_CLASSPATH="$(export_classpath "export tools/fullClasspath")"
+OLD_DEPS_CLASSPATH="$(export_classpath $SPARK_PROFILES "export oldDeps/fullClasspath")"
 
 rm -f .generated-mima*
 

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1123,7 +1123,21 @@ object DependencyOverrides {
     // SPARK-CVE: breeze (via mllib-local) declares slf4j-api 1.7.5 transitively. Maven
     // forces 2.0.7 via dependencyManagement, but sbt does not, so mllib-local/update can
     // resolve and try to fetch the ancient 1.7.5 jar. Force the managed version here.
-    dependencyOverrides += "org.slf4j" % "slf4j-api" % "2.0.7") ++
+    dependencyOverrides += "org.slf4j" % "slf4j-api" % "2.0.7",
+    // The three overrides below pin modules to the version Maven's mediation picks, so
+    // that sbt resolves jars that actually exist in a Maven-populated ~/.m2 (coursier
+    // prefers the local Maven repo once a POM is present there and fails `update` with
+    // "not found" when only another version's jar was fetched - the same failure mode
+    // that broke dev/mima in CI, see the netty note below).
+    //
+    // The kafka module poms pin jopt-simple to 3.2 (test scope) and Maven's nearest-wins
+    // takes it over kafka_2.12's transitive 5.0.4; coursier max-picks 5.0.4 instead.
+    dependencyOverrides += "net.sf.jopt-simple" % "jopt-simple" % "3.2",
+    // In ammonite 2.5.9's tree (provided dep of connect-client-jvm), Maven mediates
+    // geny to 0.7.0 (via os-lib 0.8.0) and sourcecode to 0.2.7 (via ammonite-terminal);
+    // coursier max-picks 0.7.1 / 0.3.0, which are POM-only in ~/.m2.
+    dependencyOverrides += "com.lihaoyi" %% "geny" % "0.7.0",
+    dependencyOverrides += "com.lihaoyi" %% "sourcecode" % "0.2.7") ++
     // SPARK-CVE: keep in sync with <netty.version> in pom.xml. Maven manages the top-level
     // netty modules and lets netty's internal version alignment cascade to the rest; sbt
     // does not, so it picks up the netty declared by transitive consumers (grpc/arrow),

--- a/project/SparkBuild.scala
+++ b/project/SparkBuild.scala
@@ -1129,12 +1129,16 @@ object DependencyOverrides {
     // does not, so it picks up the netty declared by transitive consumers (grpc/arrow),
     // older 4.1.91/4.1.60.Final. Without these overrides the sbt build both fails to resolve
     // (old jars are evicted, never published locally) and regresses past the Netty CVE bump.
+    // netty-transport-native-epoll/kqueue must NOT be listed here: they are consumed with
+    // platform classifiers only, so their classifier-less jars never land in ~/.m2 and
+    // coursier (which prefers the local Maven repo once a POM is present there) fails the
+    // update with "not found". They are excluded from the sbt build instead, see
+    // ExcludedDependencies below.
     Seq(
       "netty-all", "netty-buffer", "netty-codec", "netty-codec-http", "netty-codec-http2",
       "netty-codec-socks", "netty-common", "netty-handler", "netty-handler-proxy",
       "netty-resolver", "netty-transport", "netty-transport-classes-epoll",
-      "netty-transport-classes-kqueue", "netty-transport-native-epoll",
-      "netty-transport-native-kqueue", "netty-transport-native-unix-common"
+      "netty-transport-classes-kqueue", "netty-transport-native-unix-common"
     ).map(name => dependencyOverrides += "io.netty" % name % "4.1.124.Final")
 }
 
@@ -1158,7 +1162,17 @@ object ExcludedDependencies {
     excludeDependencies ++= Seq(
       ExclusionRule(organization = "com.sun.jersey"),
       ExclusionRule("javax.servlet", "javax.servlet-api"),
-      ExclusionRule("javax.ws.rs", "jsr311-api"))
+      ExclusionRule("javax.ws.rs", "jsr311-api"),
+      // SPARK-CVE: selenium-remote-driver (a test dep of every module via the parent pom)
+      // depends on these two netty modules WITHOUT a platform classifier. Maven only ever
+      // fetches their classifier jars (linux-x86_64 etc., see pom.xml), so the local Maven
+      // repo ends up with the POM but no classifier-less jar, and coursier - which prefers
+      // the local Maven repo once a POM is present there - fails `update` with "not found"
+      // (this is what silently broke dev/mima in CI). The native transports are an optional
+      // perf feature (Spark defaults to NIO; the epoll/kqueue *classes* still come from
+      // netty-transport-classes-*), so drop the native jars from the sbt build entirely.
+      ExclusionRule("io.netty", "netty-transport-native-epoll"),
+      ExclusionRule("io.netty", "netty-transport-native-kqueue"))
   )
 }
 


### PR DESCRIPTION
## Summary
This PR fixes dependency resolution failures in the sbt build when using a Maven-populated local repository (~/.m2). The issues stem from coursier's preference for the local Maven repo once a POM is present, which causes failures when only certain classifier variants of jars are available locally.

## Key Changes

**SparkBuild.scala:**
- Added three new dependency overrides to pin `jopt-simple`, `geny`, and `sourcecode` to versions that Maven's mediation selects, ensuring sbt resolves jars that actually exist in ~/.m2
- Removed `netty-transport-native-epoll` and `netty-transport-native-kqueue` from the dependency overrides list (they are now excluded instead)
- Added detailed comments explaining the coursier/Maven repo interaction and why these overrides are necessary

**ExcludedDependencies:**
- Added exclusion rules for `netty-transport-native-epoll` and `netty-transport-native-kqueue` to prevent coursier from attempting to fetch classifier-less jars that don't exist in ~/.m2
- These native transports are optional performance features; the sbt build uses the classifier-based jars (linux-x86_64, etc.) or falls back to NIO, so excluding them is safe

**dev/mima:**
- Refactored classpath export logic into a new `export_classpath()` helper function
- The helper properly buffers sbt output and displays it on failure, making it easier to diagnose sbt failures in CI
- This fixes silent failures in dev/mima when sbt's dependency resolution fails

## Implementation Details
The root cause is that selenium-remote-driver (a test dependency) depends on netty native transport modules without platform classifiers. Maven only fetches the classifier variants (e.g., linux-x86_64), leaving the local repo with POMs but no classifier-less jars. When coursier prefers the local Maven repo (once a POM is present), it fails to find the classifier-less jars and aborts with "not found" errors.

The fix uses two complementary strategies:
1. For modules where Maven's mediation picks a specific version, override sbt's resolution to match
2. For modules where only classifier variants should be used, exclude the classifier-less jars entirely

https://claude.ai/code/session_01HdmNouFA7cCw3J11Xb7Djm