### PR TITLE
[SPARK-55206][PYTHON][SQL] Guard UDF transpilation against semantic divergences

### DIFF
--- a/python/pyspark/sql/tests/test_udf_transpile_hypothesis.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_hypothesis.py
@@ -31,9 +31,14 @@ silence.
 
 The suite is gated on two things, both required:
 
-* the ``RUN_HYPOTHESIS`` env var must be present in the environment
-  (its value doesn't matter, only its presence), and
+* the ``RUN_HYPOTHESIS`` env var must be set to a truthy value
+  (``1``, ``true``, or ``yes``, case-insensitive), and
 * the ``hypothesis`` package must be installed.
+
+The gate is value-based rather than presence-based because CI always sets
+``RUN_HYPOTHESIS`` (to ``"true"`` or ``"false"``) via the transpile
+precondition in ``build_and_test.yml``; mere presence must not opt in, or
+the slow suite would run on every PySpark job.
 
 If either gate is unmet the entire suite is skipped cleanly so it never
 becomes a CI tax for folks who haven't opted in. In CI, this opt-in suite
@@ -77,14 +82,25 @@ _SENTINEL_RAISED = object()
 
 _HYPOTHESIS_ENV = "RUN_HYPOTHESIS"
 _have_hypothesis = have_package("hypothesis")
-# Presence-based: any value (including empty) opts in. We just check for the
-# key being in os.environ so e.g. `RUN_HYPOTHESIS= python ...` still counts.
-_hypothesis_enabled = _HYPOTHESIS_ENV in os.environ
+
+
+def _env_opts_in(value: Optional[str]) -> bool:
+    """Value-based opt-in: only 1/true/yes (case-insensitive) enable the suite.
+
+    CI always sets ``RUN_HYPOTHESIS`` -- to ``"true"`` or ``"false"`` -- via the
+    transpile precondition in ``build_and_test.yml``, so a presence-based check
+    would run this very slow suite on every PySpark job regardless of the
+    gating decision.
+    """
+    return value is not None and value.strip().lower() in ("1", "true", "yes")
+
+
+_hypothesis_enabled = _env_opts_in(os.environ.get(_HYPOTHESIS_ENV))
 # Transpilation is only supported in regular (non-Connect) Spark for now,
 # so the hypothesis suite skips cleanly under a pyspark-client-only install.
 _regular_spark = not is_remote_only()
 _skip_reason = (
-    f"Set {_HYPOTHESIS_ENV} in the environment to run; hypothesis must also be installed, "
+    f"Set {_HYPOTHESIS_ENV}=1 (or true/yes) to run; hypothesis must also be installed, "
     "and the suite only runs under regular (non-Connect) Spark."
 )
 
@@ -657,6 +673,16 @@ class UDFTranspileHypothesisGatingTests(unittest.TestCase):
 
     def test_skip_reason_mentions_env_var(self):
         self.assertIn(_HYPOTHESIS_ENV, _skip_reason)
+
+    def test_env_gate_is_value_based(self):
+        # CI always sets RUN_HYPOTHESIS (to "true" or "false") via the
+        # transpile precondition in build_and_test.yml. If this gate ever
+        # regresses to presence-based, the very slow suite silently runs on
+        # every PySpark job. Pin the contract from both directions.
+        for opted_in in ("1", "true", "TRUE", "yes", " True "):
+            self.assertTrue(_env_opts_in(opted_in), f"{opted_in!r} must opt in")
+        for opted_out in (None, "", "0", "false", "FALSE", "no", "off"):
+            self.assertFalse(_env_opts_in(opted_out), f"{opted_out!r} must NOT opt in")
 
 
 if __name__ == "__main__":

--- a/python/pyspark/sql/tests/test_udf_transpile_hypothesis.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_hypothesis.py
@@ -48,7 +48,7 @@ To run locally::
         python/run-tests --testnames pyspark.sql.tests.test_udf_transpile_hypothesis
 
 Set ``RUN_HYPOTHESIS_MAX_EXAMPLES`` to override the per-test example count
-(default 100, kept small for CI).
+(default 1000).
 """
 
 import os
@@ -115,7 +115,7 @@ if _have_hypothesis:
     # overflow.  Worse, the Python UDF runner silently wraps out-of-range
     # return values even with ANSI=True, so "both raised" never fires for
     # overflow values and the test sees a spurious mismatch instead.
-    # 2**61 is safe for all operations: (2**61)*3 ≈ 6.9e18 < 9.2e18 = Long.MAX.
+    # 2**61 is safe for all operations: (2**61)*3 ~= 6.9e18 < 9.2e18 = Long.MAX.
     _LONG_ARITH_BOUND = 2**61
     _long_arith_strategy = st.one_of(
         st.none(),

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -673,9 +673,12 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             return 1 if x > 0 else "neg"
 
         def mixed_if(x):
+            # Single top-level `if`/`else` so the If-statement lowering path
+            # (not the "more than one statement" fallback) exercises the guard.
             if x > 0:
                 return "pos"
-            return x
+            else:
+                return x
 
         # Positive control: matching-category branches must still transpile, so
         # the guard does not over-refuse.

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -658,6 +658,74 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
                     [result] = df.select(pudf("a")).collect()
                     self.assertEqual(result[0], expected, f"{label}: interpreted mismatch")
 
+    def test_udf_transpile_falls_back_for_mismatched_branch_types(self):
+        # An if/ternary whose two branches produce different Spark categories
+        # (e.g. numeric vs string) would lower to a CASE WHEN whose branch
+        # values share no common type under ANSI. That node is carried as a
+        # child of the TranspiledPythonUDF and is type-checked by CheckAnalysis
+        # before ConvertToCatalyst can drop it, so without a guard the whole
+        # query would fail analysis instead of falling back. The transpiler must
+        # refuse and run the UDF as interpreted Python.
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def mixed_ternary(x):
+            return 1 if x > 0 else "neg"
+
+        def mixed_if(x):
+            if x > 0:
+                return "pos"
+            return x
+
+        # Positive control: matching-category branches must still transpile, so
+        # the guard does not over-refuse.
+        def homogeneous(x):
+            return x if x > 0 else 0
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+
+        with self.sql_conf(
+            {
+                "spark.sql.experimental.optimizer.transpilePyUDFs": True,
+                "spark.sql.ansi.enabled": True,
+            }
+        ):
+            # Inputs are chosen to take the string-returning branch so the
+            # interpreted result is unambiguous.
+            mismatch_cases = [
+                ("mixed_ternary", mixed_ternary, Row(a=-3), "neg"),
+                ("mixed_if", mixed_if, Row(a=10), "pos"),
+            ]
+            for label, func, row, expected in mismatch_cases:
+                with self.subTest(case=label):
+                    with _warnings.catch_warnings(record=True) as caught:
+                        _warnings.simplefilter("always")
+                        pudf = UserDefinedFunction(func, StringType())
+                    self.assertEqual(
+                        [],
+                        pudf.transpiled,
+                        f"{label}: mismatched branch types must NOT be lowered to Catalyst",
+                    )
+                    fallback = [w for w in caught if "Unable to transpile" in str(w.message)]
+                    self.assertTrue(fallback, f"{label}: expected a fallback warning")
+                    df = self.spark.createDataFrame([row], schema=long_schema)
+                    # Must run without an analysis failure and match interpreted Python.
+                    [result] = df.select(pudf("a")).collect()
+                    self.assertEqual(result[0], expected, f"{label}: interpreted mismatch")
+
+            with self.subTest(case="homogeneous"):
+                pudf = UserDefinedFunction(homogeneous, LongType())
+                self.assertNotEqual(
+                    [],
+                    pudf.transpiled,
+                    "matching-category branches must still transpile",
+                )
+                df = self.spark.createDataFrame(
+                    [Row(a=5), Row(a=-3)], schema=long_schema
+                )
+                results = [r[0] for r in df.select(pudf("a")).collect()]
+                self.assertEqual(results, [5, 0], "homogeneous branch result mismatch")
+
     def test_udf_transpile_is_none_semantics(self):
         # `x is None` and `None is x` (and their `is not` variants) should
         # transpile to isNull/isNotNull. Any other identity check (`x is 0`,

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -727,6 +727,189 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
                 results = [r[0] for r in df.select(pudf("a")).collect()]
                 self.assertEqual(results, [5, 0], "homogeneous branch result mismatch")
 
+    def test_udf_transpile_falls_back_for_cross_category_eq(self):
+        # `x == True` on a numeric column would lower to `x = true`, which
+        # fails ANSI analysis (BIGINT vs BOOLEAN) while the option is still a
+        # child of the TranspiledPythonUDF -- breaking a working UDF. The
+        # category gate must refuse so it runs as interpreted Python.
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def eq_true(x):
+            return x == True  # noqa: E712
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(eq_true, BooleanType())
+            self.assertEqual([], pudf.transpiled, "cross-category == must not transpile")
+            df = self.spark.createDataFrame([Row(a=5), Row(a=1)], schema=long_schema)
+            results = [r[0] for r in df.select(pudf("a")).collect()]
+            self.assertEqual(results, [5 == True, 1 == True])
+
+    def test_udf_transpile_falls_back_for_return_wrapped_bool_branch(self):
+        # If-statement branches arrive as ast.Return nodes; the branch-category
+        # guard must see through the wrapper. A boolean-returning branch vs a
+        # numeric one previously slipped past the guard and failed analysis
+        # (CASE WHEN [BOOLEAN, INT]) instead of falling back.
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def mixed(x):
+            if x > 0:
+                return x > 5
+            else:
+                return 1
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(mixed, LongType())
+            self.assertEqual([], pudf.transpiled, "bool-vs-int branches must not transpile")
+            df = self.spark.createDataFrame([Row(a=-3)], schema=long_schema)
+            [result] = df.select(pudf("a")).collect()
+            self.assertEqual(result[0], 1)
+
+    def test_udf_transpile_falls_back_for_plain_self_param(self):
+        # A plain function whose first parameter is literally named `self`
+        # must not be confused with a bound __call__ method: stripping it
+        # previously emitted `_udf_param_-1` and threw an AnalysisException
+        # at call construction.
+        import warnings as _warnings
+
+        def weird(self, other):
+            return self + other
+
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(weird, LongType())
+            self.assertEqual([], pudf.transpiled, "plain 'self' param must not transpile")
+            df = self.spark.createDataFrame([Row(a=2, b=3)])
+            [result] = df.select(pudf("a", "b")).collect()
+            self.assertEqual(result[0], 5)
+
+    def test_udf_transpile_falls_back_for_wraps_decorated_function(self):
+        # inspect.getsource follows __wrapped__, so a functools.wraps-decorated
+        # UDF previously transpiled the WRAPPED function's source while the
+        # interpreted path ran the wrapper -- a silent wrong result.
+        import functools
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def base(x):
+            return x + 1
+
+        @functools.wraps(base)
+        def wrapper(x):
+            return base(x) * 10
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(wrapper, LongType())
+            self.assertEqual([], pudf.transpiled, "wraps-decorated UDF must not transpile")
+            df = self.spark.createDataFrame([Row(a=5)], schema=long_schema)
+            [result] = df.select(pudf("a")).collect()
+            self.assertEqual(result[0], 60, "must run the wrapper, not the wrapped source")
+
+    def test_udf_transpile_falls_back_for_none_in_boolop(self):
+        # Python's `None and x` short-circuits to None; Spark's three-valued
+        # `null AND false` is false. A literal None operand must force a
+        # fallback rather than silently diverge.
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def none_and(x):
+            return None and (x > 0)
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(none_and, BooleanType())
+            self.assertEqual([], pudf.transpiled, "literal None in and/or must not transpile")
+            df = self.spark.createDataFrame([Row(a=-5)], schema=long_schema)
+            [result] = df.select(pudf("a")).collect()
+            self.assertIsNone(result[0])
+
+    def test_udf_transpile_preserves_auto_column_name(self):
+        # The auto-generated column name must stay `f(a)` whether or not the
+        # rewrite engages; the TranspiledPythonUDF wrapper (and its option
+        # children) must not leak into user-visible schema names.
+        from pyspark.sql.types import StructField, StructType
+
+        def plus_four(x):
+            return x + 4
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        df = self.spark.createDataFrame([Row(a=1)], schema=long_schema)
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(plus_four, LongType())
+            self.assertTrue(pudf.transpiled)
+            self.assertEqual(df.select(pudf("a")).columns, ["plus_four(a)"])
+
+    def test_udf_transpile_arity_mismatch_falls_back(self):
+        # Calling with the wrong number of arguments is a user error that must
+        # surface as the standard Python-side TypeError, not be silently
+        # absorbed by a transpiled constant (zero-param case) nor raise a
+        # misleading "internal error" AnalysisException (too-few-args case).
+        import warnings as _warnings
+        from pyspark.errors import PythonException
+        from pyspark.sql.types import StructField, StructType
+
+        def zero():
+            return 42
+
+        def two(x, y):
+            return x + y
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        df = self.spark.createDataFrame([Row(a=5)], schema=long_schema)
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf_zero = UserDefinedFunction(zero, LongType())
+                pudf_two = UserDefinedFunction(two, LongType())
+            with self.assertRaises(PythonException):
+                df.select(pudf_zero("a")).collect()
+            with self.assertRaises(PythonException):
+                df.select(pudf_two("a")).collect()
+
+    def test_udf_transpile_decimal_input_falls_back(self):
+        # Python receives decimal.Decimal objects, which raise TypeError when
+        # mixed with float literals; the transpiled numeric lowering would
+        # silently succeed. Decimal columns must fall back to interpreted
+        # Python (pruned by input category at analysis time).
+        from pyspark.errors import PythonException
+
+        def add_half(x):
+            return x + 1.5
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(add_half, StringType())
+            self.assertTrue(pudf.transpiled, "numeric option should still be produced")
+            df = self.spark.sql("SELECT CAST(1.0 AS DECIMAL(10,2)) AS d")
+            with self.assertRaises(PythonException):
+                df.select(pudf("d")).collect()
+
+    def test_udf_transpile_collated_string_falls_back(self):
+        # Under a non-binary collation Spark's `=` follows collation rules
+        # ('abc' = 'ABC' is true under UTF8_LCASE) while Python compares
+        # codepoints. Collated columns must fall back to interpreted Python.
+        def eq_abc(s):
+            return s == "ABC"
+
+        with self.sql_conf(_TRANSPILE_ON):
+            pudf = UserDefinedFunction(eq_abc, BooleanType())
+            self.assertTrue(pudf.transpiled, "string option should still be produced")
+            df = self.spark.sql("SELECT 'abc' COLLATE UTF8_LCASE AS s")
+            [result] = df.select(pudf("s")).collect()
+            self.assertIs(result[0], False, "must match Python, not collation semantics")
+
     def test_udf_transpile_is_none_semantics(self):
         # `x is None` and `None is x` (and their `is not` variants) should
         # transpile to isNull/isNotNull. Any other identity check (`x is 0`,
@@ -1150,9 +1333,8 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
     def test_udf_transpile_known_value_divergences(self):
         # Transpile but DIVERGE from Python (documented in transpile.py; pinned so
         # a future fix is noticed): unguarded arithmetic on NULL yields NULL
-        # (Python raises TypeError), NaN > 0 is True (Python False; Spark orders
-        # NaN highest), and comparing to a cross-type literal coerces (int == "5"
-        # -> True; Python False). Mixed str/numeric arithmetic is handled or falls
+        # (Python raises TypeError), and NaN > 0 is True (Python False; Spark
+        # orders NaN highest). Mixed str/numeric arithmetic is handled or falls
         # back -- see test_udf_transpile_string_operands{,_fall_back}.
         unguarded = lambda x: x + 1  # noqa: E731
         nan_gt = lambda x: (x > 0) if x is not None else None  # noqa: E731
@@ -1161,8 +1343,12 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         self.assertEqual(
             self._vals(nan_gt, BooleanType(), "a double", [(float("nan"),), (1.0,)]), [True, True]
         )
+        # `x == "5"` used to be pinned as a coercion divergence (int == "5" ->
+        # True). The eq category gate now drops the numeric variant, so on a
+        # long column the string option is pruned and the UDF falls back to
+        # interpreted Python -- matching Python's cross-type == (always False).
         self.assertEqual(
-            self._vals(eq_strlit, BooleanType(), "a long", [(5,), (3,)]), [True, False]
+            self._vals(eq_strlit, BooleanType(), "a long", [(5,), (3,)]), [False, False]
         )
 
     def test_udf_transpile_overflow_and_modulo_zero_raise(self):

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -748,6 +748,56 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             results = [r[0] for r in df.select(pudf("a")).collect()]
             self.assertEqual(results, [5 == True, 1 == True])
 
+    def test_udf_transpile_falls_back_for_nested_ternary_eq(self):
+        # A ternary operand used inside `==` must contribute its branches'
+        # category, not the old "numeric" catch-all: `("5" if c else "6") == 5`
+        # previously passed the equality guard as numeric-vs-numeric and
+        # Spark's string-number coercion silently returned True where Python's
+        # cross-type == is False. (Reported by Codex review on PR #34.)
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def nested_ternary_eq(x):
+            return ("5" if x > 0 else "6") == 5
+
+        def none_branch_ternary_eq(x):
+            return ("5" if x > 0 else None) == 5
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        df = self.spark.createDataFrame([Row(a=5), Row(a=-5)], schema=long_schema)
+        with self.sql_conf(_TRANSPILE_ON):
+            for func in [nested_ternary_eq, none_branch_ternary_eq]:
+                with self.subTest(func=func.__name__):
+                    with _warnings.catch_warnings(record=True):
+                        _warnings.simplefilter("always")
+                        pudf = UserDefinedFunction(func, BooleanType())
+                    self.assertEqual(
+                        [], pudf.transpiled, "string-ternary == int must not transpile"
+                    )
+                    results = [r[0] for r in df.select(pudf("a")).collect()]
+                    self.assertEqual(results, [False, False], "must match Python's ==")
+
+    def test_udf_transpile_falls_back_for_bool_arithmetic(self):
+        # `(x > 0) + 1` is valid Python (True + 1 == 2), but the lowered
+        # Add(boolean, int) fails ANSI analysis. The category of a
+        # boolean-producing operand is now "bool" (not the numeric catch-all),
+        # so this refuses and runs as interpreted Python.
+        import warnings as _warnings
+        from pyspark.sql.types import StructField, StructType
+
+        def bool_plus_one(x):
+            return (x > 0) + 1
+
+        long_schema = StructType([StructField("a", LongType(), nullable=True)])
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(bool_plus_one, LongType())
+            self.assertEqual([], pudf.transpiled, "bool arithmetic must not transpile")
+            df = self.spark.createDataFrame([Row(a=5), Row(a=-5)], schema=long_schema)
+            results = [r[0] for r in df.select(pudf("a")).collect()]
+            self.assertEqual(results, [2, 1])
+
     def test_udf_transpile_falls_back_for_return_wrapped_bool_branch(self):
         # If-statement branches arrive as ast.Return nodes; the branch-category
         # guard must see through the wrapper. A boolean-returning branch vs a

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -723,9 +723,7 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
                     pudf.transpiled,
                     "matching-category branches must still transpile",
                 )
-                df = self.spark.createDataFrame(
-                    [Row(a=5), Row(a=-3)], schema=long_schema
-                )
+                df = self.spark.createDataFrame([Row(a=5), Row(a=-3)], schema=long_schema)
                 results = [r[0] for r in df.select(pudf("a")).collect()]
                 self.assertEqual(results, [5, 0], "homogeneous branch result mismatch")
 

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -84,6 +84,7 @@ class AbstractTranspiler(object):
     ) -> Optional[Column]:
         pass
 
+
 def _is_definitely_basic_type(node: ast.AST) -> bool:
     """
     Return True when ``node`` is statically guaranteed to produce a Python
@@ -102,6 +103,7 @@ def _is_definitely_basic_type(node: ast.AST) -> bool:
             return True
         case _:
             return False
+
 
 def _is_definitely_boolean(node: ast.AST) -> bool:
     """Return True when ``node`` is statically guaranteed to produce a Python

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -65,7 +65,7 @@ class AbstractTranspiler(object):
     """Base class for transpilers. All experimental."""
 
     varieties: dict[str, type["AbstractTranspiler"]] = {}
-    # Specify the "friendly" name a user can add to spark.sql.experimental.optimizer.transpilers
+    # Specify the "friendly" name a user can add to spark.sql.experimental.optimizer.pyTranspilers
     # to enable this transpiler.
     variety: str = ""
 
@@ -110,7 +110,7 @@ def _is_definitely_boolean(node: ast.AST) -> bool:
     Used to gate ``if``/ternary lowering: we only allow the test expression
     into Catalyst's ``when(coalesce(test, false), ...)`` form when it provably
     produces a boolean. Everything else (bare Name, arithmetic, function calls,
-    subscript, …) must force a fallback to interpreted Python instead of
+    subscript, ...) must force a fallback to interpreted Python instead of
     silently diverging.
     """
     match node:
@@ -127,62 +127,6 @@ def _is_definitely_boolean(node: ast.AST) -> bool:
         case ast.IfExp(body=body, orelse=orelse):
             # Ternary is boolean only if both branches are.
             return _is_definitely_boolean(body) and _is_definitely_boolean(orelse)
-        case _:
-            return False
-
-
-def _is_definitely_non_boolean(node: ast.AST) -> bool:
-    """Return True when ``node`` is statically guaranteed to evaluate to a
-    value that is *not* a Python ``bool``.
-
-    Used to gate the bitwise lowering of ``and`` / ``or`` / ``not``: Python's
-    short-circuit operators return one of their operands rather than a strict
-    bool, so ``x or 0`` against an int column would silently get
-    bitwise-style behaviour from Spark's ``|`` instead of Python's truthiness
-    fallback. We can't always tell statically (a bare ``ast.Name`` could be
-    bound to any type), so we conservatively only refuse to lower when an
-    operand is *provably* non-boolean -- numeric / string literals, an
-    arithmetic ``BinOp``, a numeric ``UnaryOp(USub/UAdd)``. Everything else
-    (Names, Compare, Not, nested BoolOps, IfExp, conservative cases) is
-    treated as "possibly boolean" and we let the bitwise lowering proceed,
-    relying on the input being a boolean column at runtime.
-    """
-    match node:
-        case ast.Constant(value=v):
-            # ``True`` and ``False`` are themselves bool; ``None`` we
-            # accept (it round-trips through coalesce). Everything else
-            # is definitely not bool.
-            return not (v is None or isinstance(v, bool))
-        case ast.BinOp(
-            op=ast.Add()
-            | ast.Sub()
-            | ast.Mult()
-            | ast.Div()
-            | ast.FloorDiv()
-            | ast.Mod()
-            | ast.Pow()
-            | ast.LShift()
-            | ast.RShift()
-            | ast.MatMult()
-        ):
-            # Arithmetic / shift BinOps produce numeric (or matrix) results,
-            # never booleans, so they're provably non-boolean. Bitwise
-            # ``&`` / ``|`` / ``^`` are deliberately NOT matched: they
-            # produce a boolean when both operands are boolean (e.g.
-            # ``(x > 0) & (y > 0)``), so leaving them in the "possibly
-            # boolean" bucket lets the BoolOp / Not lowering proceed.
-            return True
-        case ast.UnaryOp(op=ast.USub()) | ast.UnaryOp(op=ast.UAdd()):
-            return True
-        case ast.IfExp(body=body, orelse=orelse):
-            # Conditional only known non-boolean if both branches are.
-            return _is_definitely_non_boolean(body) and _is_definitely_non_boolean(orelse)
-        case ast.Call():
-            # Function calls: we don't know the return type statically, so we
-            # can't claim they're non-boolean. Leave as "possibly boolean" and
-            # let the caller attempt lowering; if the call itself is not
-            # supported the catch-all arm will raise UnsupportedOperationException.
-            return False
         case _:
             return False
 
@@ -211,12 +155,37 @@ class CatalystTranspiler(AbstractTranspiler):
             return lit(None)
         return self._convert_chunk(params, statements[0])
 
+    def _safe_category(self, params: List[str], node: Optional[ast.AST]) -> Optional[str]:
+        """Best-effort input-type category for an if/else branch, or ``None`` when
+        it can't be pinned down statically.
+
+        Used only to compare the two branches of an if/ternary. A ``None`` result
+        means "treat as compatible" (don't force a fallback): the node is absent,
+        is a bare ``None`` literal (which unifies with any branch type via
+        ``coalesce``/``Cast``), or its category can't be determined.
+        """
+        if node is None:
+            return None
+        if isinstance(node, ast.Constant) and node.value is None:
+            return None
+        # Comparisons / ``not`` / boolean ops produce a boolean column; classify
+        # them as "bool" (``_category``'s catch-all would mislabel them numeric).
+        if _is_definitely_boolean(node):
+            return "bool"
+        try:
+            return self._category(params, node)
+        except UnsupportedOperationException:
+            return None
+
     def _convert_if_like(
         self,
+        params: List[str],
         test_col: Column,
         body_col: Column,
         else_col: Column,
         test_node: ast.AST,
+        body_node: Optional[ast.AST],
+        else_node: Optional[ast.AST],
     ) -> Column:
         # We cannot soundly lower a generic Python truthiness test here.
         # Python truthiness depends on the runtime input type and value:
@@ -233,6 +202,22 @@ class CatalystTranspiler(AbstractTranspiler):
             raise UnsupportedOperationException(
                 f"bare truthiness tests ({ast.dump(test_node)}) in if-expressions are "
                 " not currently supported by the transpiler"
+            )
+        # When the two branches resolve to concrete but different categories
+        # (e.g. numeric vs string), the lowered ``when(...).otherwise(...)`` is a
+        # CASE WHEN whose branch values share no common type under ANSI. That node
+        # is carried as a child of the TranspiledPythonUDF and is type-checked by
+        # CheckAnalysis *before* ConvertToCatalyst can drop it, so it would fail
+        # the whole query rather than fall back. Refuse here so the UDF runs as
+        # interpreted Python instead. Branches whose category we can't pin down
+        # (e.g. a bare ``None``) are treated as compatible and don't force this.
+        body_cat = self._safe_category(params, body_node)
+        else_cat = self._safe_category(params, else_node)
+        if body_cat is not None and else_cat is not None and body_cat != else_cat:
+            raise UnsupportedOperationException(
+                f"if/else branches have incompatible categories ({body_cat} vs "
+                f"{else_cat}); the lowered CASE WHEN has no common type under ANSI, "
+                "so the transpiler falls back to interpreted Python"
             )
         safe_test = coalesce(test_col, lit(False))
         return when(safe_test, body_col).otherwise(else_col)
@@ -447,17 +432,23 @@ class CatalystTranspiler(AbstractTranspiler):
                 # Ternary `body if test else orelse` -- shares the
                 # NULL-as-falsy lowering with the if-statement case.
                 return self._convert_if_like(
+                    params,
                     self._convert_chunk(params, test),
                     self._convert_chunk(params, body_expr),
                     self._convert_chunk(params, orelse_expr),
                     test,
+                    body_expr,
+                    orelse_expr,
                 )
             case ast.If(test, success, orelse):
                 return self._convert_if_like(
+                    params,
                     self._convert_chunk(params, test),
                     self._convert_branch(params, success, "body"),
                     self._convert_branch(params, orelse, "else body"),
                     test,
+                    success[0] if success else None,
+                    orelse[0] if orelse else None,
                 )
             case ast.Compare(left, ops, comps):
                 if len(ops) != 1 or len(comps) != 1:
@@ -559,7 +550,13 @@ class CatalystTranspiler(AbstractTranspiler):
                         if lc == rc == "numeric":
                             # Python's `%` takes the sign of the divisor; Spark's
                             # takes the dividend's. `sign(b) * pmod(sign(b) * a,
-                            # abs(b))` reproduces Python for any non-zero divisor.
+                            # abs(b))` reproduces Python for every non-zero divisor
+                            # except at the LongType overflow boundaries -- `a =
+                            # Long.MinValue` with `b < 0` (the `sign(b) * a` negate
+                            # overflows) and `b = Long.MinValue` (the `abs(b)`
+                            # overflows) -- where this raises ARITHMETIC_OVERFLOW
+                            # under ANSI while Python returns a value. That matches
+                            # the documented overflow caveat for `+`/`-`/`*` above.
                             # Use a CASE-based integer sign rather than sign() to
                             # avoid promoting operands to DoubleType, which loses
                             # precision near LongType boundaries.

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -168,6 +168,12 @@ class CatalystTranspiler(AbstractTranspiler):
         """
         if node is None:
             return None
+        # If-statement branches arrive as ``Return`` statements; classify the
+        # returned value, not the statement wrapper (``_is_definitely_boolean``
+        # has no ``Return`` case, so without this a boolean-returning branch
+        # would fall through to ``_category``'s numeric catch-all).
+        if isinstance(node, ast.Return):
+            return self._safe_category(params, node.value)
         if isinstance(node, ast.Constant) and node.value is None:
             return None
         # Comparisons / ``not`` / boolean ops produce a boolean column; classify
@@ -227,7 +233,7 @@ class CatalystTranspiler(AbstractTranspiler):
     def _lower_eq(
         self,
         params: List[str],
-        left_col: Column,
+        left_node: ast.AST,
         right_node: ast.AST,
         equal: bool,
     ) -> Column:
@@ -240,12 +246,28 @@ class CatalystTranspiler(AbstractTranspiler):
         the UDF as ``None`` rather than the bool Python would have
         produced. Hand-roll the four cases via ``when`` branches.
 
-        Caveat: when the operands are different types Spark coerces before
-        comparing (e.g. an int column ``== "5"`` is True after casting the
-        string), whereas Python's ``==`` is False across unequal types. The
-        transpiler can't see column types, so this divergence is documented
-        rather than guarded.
+        When the two operands resolve to concrete but DIFFERENT categories
+        (e.g. ``x == True`` on a numeric column, or ``x == "5"`` under the
+        numeric variant), the lowered ``=`` either fails analysis under ANSI
+        (bool vs bigint) -- which would break a working UDF since the option
+        is type-checked before ConvertToCatalyst can drop it -- or coerces
+        where Python's ``==`` is simply False. Refuse those so the UDF falls
+        back to interpreted Python. A ``None`` literal operand stays allowed
+        (the four-branch NULL handling above reproduces Python exactly).
+
+        One value-level difference remains (needs runtime values, so it is
+        documented, not guarded): Spark treats ``NaN = NaN`` as true, while
+        Python's ``nan == nan`` is False.
         """
+        lc = self._safe_category(params, left_node)
+        rc = self._safe_category(params, right_node)
+        if lc is not None and rc is not None and lc != rc:
+            raise UnsupportedOperationException(
+                f"`==`/`!=` operands have incompatible categories ({lc} vs {rc}); "
+                "Python compares across types as unequal while Spark would coerce "
+                "or fail analysis, so the transpiler falls back to interpreted Python"
+            )
+        left_col = self._convert_chunk(params, left_node)
         right_col = self._convert_chunk(params, right_node)
         left_null = left_col.isNull()
         right_null = right_col.isNull()
@@ -418,6 +440,19 @@ class CatalystTranspiler(AbstractTranspiler):
                         "lower this and the UDF falls back to interpreted "
                         "Python"
                     )
+                # A literal None operand short-circuits differently: Python's
+                # `None and (x > 0)` returns None regardless of x, but Spark's
+                # three-valued `null AND false` is false (and `null OR true` is
+                # true), so the lowered form diverges. `_is_definitely_boolean`
+                # accepts None for `not`/if-test contexts where coalesce handles
+                # it; here it must force a fallback instead.
+                if any(isinstance(v, ast.Constant) and v.value is None for v in values):
+                    raise UnsupportedOperationException(
+                        "literal None operand in `and` / `or` cannot be lowered: "
+                        "Spark's three-valued logic diverges from Python's "
+                        "short-circuit-return-operand semantics, so the UDF "
+                        "falls back to interpreted Python"
+                    )
                 cols = [self._convert_chunk(params, v) for v in values]
                 if isinstance(op, ast.And):
                     result = cols[0]
@@ -483,11 +518,9 @@ class CatalystTranspiler(AbstractTranspiler):
                         else:
                             return subject_col.isNotNull()
                     case ast.Eq():
-                        left_col = self._convert_chunk(params, left)
-                        return self._lower_eq(params, left_col, comp, equal=True)
+                        return self._lower_eq(params, left, comp, equal=True)
                     case ast.NotEq():
-                        left_col = self._convert_chunk(params, left)
-                        return self._lower_eq(params, left_col, comp, equal=False)
+                        return self._lower_eq(params, left, comp, equal=False)
                     case ast.Lt():
                         return self._lower_value_compare(
                             params, left, comp, lambda l, r: l < r, "<"
@@ -714,10 +747,17 @@ def _get_src_ast_from_func(func: Callable) -> Tuple[Optional[str], Optional[ast.
         src = textwrap.dedent(src).strip()
         ast_info = ast.parse(src)
     except Exception:
-        if hasattr(func, "__call__"):
-            src = inspect.getsource(func.__call__)
+        try:
+            # getattr keeps mypy happy: `__call__` on a bare Callable is
+            # not attribute-accessible in the type system.
+            src = inspect.getsource(getattr(func, "__call__"))
             src = textwrap.dedent(src).strip()
             ast_info = ast.parse(src)
+        except Exception:
+            # No usable source (REPL/stdin definition, builtin, ...) --
+            # return cleanly so the caller reports "cannot transpile"
+            # instead of surfacing an UnboundLocalError as the reason.
+            return None, None
     return src, ast_info
 
 
@@ -802,6 +842,24 @@ def _transpile_func(
     column types, or falls back to the Python UDF when none match.
     """
     try:
+        # A functools.wraps-style decorator makes ``inspect.getsource`` return
+        # the WRAPPED function's source (getsource follows ``__wrapped__``),
+        # while the UDF actually executes the wrapper. Transpiling would
+        # silently reproduce the wrong behavior, so refuse and fall back.
+        if (
+            getattr(func, "__wrapped__", None) is not None
+            or getattr(getattr(func, "__call__", None), "__wrapped__", None) is not None
+        ):
+            return (
+                [],
+                [
+                    "decorated callables (functools.wraps) are not supported: "
+                    "the visible source is the wrapped function's, not the "
+                    "wrapper's, so transpilation would change behavior"
+                ],
+                [],
+                [],
+            )
         src, ast = _get_src_ast_from_func(func)
         if ast is None:
             return ([], ["Error getting ast for function, cannot transpile"], [], [])
@@ -835,6 +893,24 @@ def _transpile_func(
                 [],
             )
         params = _get_parameter_list(function_ast)
+        # The transpiler strips a leading ``self`` on the assumption that the
+        # source came from a bound ``__call__`` / method whose receiver is not
+        # supplied at the call site. A PLAIN function whose first parameter
+        # happens to be named ``self`` breaks that assumption: every arg IS
+        # supplied at the call site, and stripping would misnumber the
+        # ``_udf_param_N`` placeholders (emitting ``_udf_param_-1``). Refuse
+        # and fall back rather than guess.
+        if params and params[0] == "self" and inspect.isfunction(func):
+            return (
+                [],
+                [
+                    "plain function with first parameter named 'self' is "
+                    "ambiguous to the transpiler's self-stripping; falling "
+                    "back to interpreted Python"
+                ],
+                [],
+                [],
+            )
         # Strip ``self`` for the caller-facing param list -- callers will
         # match user-supplied kwargs against this, and the user doesn't
         # name ``self`` at the call site.

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -385,9 +385,43 @@ class CatalystTranspiler(AbstractTranspiler):
                 )
             case ast.Return(value=value) if value is not None:
                 return self._category(params, value)
+            case ast.IfExp(body=if_body, orelse=if_orelse):
+                # A ternary's category is its branches' common category. Without
+                # this arm the catch-all labeled every IfExp "numeric", so e.g.
+                # `("5" if c else "6") == 5` passed the equality guard as
+                # numeric-vs-numeric and Spark's string-number coercion silently
+                # diverged from Python's cross-type `==` (always False). A
+                # None-literal branch adopts the other branch's category (NULL
+                # unifies with any type in the lowered CASE WHEN); mismatched or
+                # all-None branches raise so the variant is dropped.
+                def branch_category(b: ast.AST) -> Optional[str]:
+                    if isinstance(b, ast.Constant) and b.value is None:
+                        return None
+                    return self._category(params, b)
+
+                body_cat = branch_category(if_body)
+                else_cat = branch_category(if_orelse)
+                if body_cat is not None and else_cat is not None and body_cat != else_cat:
+                    raise UnsupportedOperationException(
+                        f"ternary branches have mismatched categories ({body_cat} "
+                        f"vs {else_cat}) and cannot drive operator selection"
+                    )
+                result_cat = body_cat if body_cat is not None else else_cat
+                if result_cat is None:
+                    raise UnsupportedOperationException(
+                        "ternary with all-None branches has no usable column category"
+                    )
+                return result_cat
+            case _ if _is_definitely_boolean(node):
+                # Comparisons, `not`, and boolean ops produce a boolean column.
+                # Labeling them "numeric" (the old catch-all) let booleans into
+                # arithmetic/equality lowerings where ANSI analysis fails (e.g.
+                # `(x > 0) + 1`, valid Python) instead of falling back.
+                return "bool"
             case _:
-                # Comparisons / boolean ops / unary / None / ternary don't drive
-                # concat/repeat selection; treat as numeric for category purposes.
+                # Remaining nodes (unsupported calls, subscripts, ...) don't
+                # drive concat/repeat selection and are rejected later by
+                # `_convert_chunk`; treat as numeric for category purposes.
                 return "numeric"
 
     def _convert_chunk(self, params: List[str], body: ast.AST | None) -> Column:

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -220,22 +220,26 @@ class UserDefinedFunction:
         from pyspark.sql import SparkSession
 
         session = SparkSession._instantiatedSession
+
         # A nondeterministic UDF must not be transpiled: replacing it with a plain
         # Catalyst expression would let the optimizer fold/reorder/duplicate it,
         # discarding the nondeterminism barrier. (asNondeterministic() also clears
         # any options set here, for the udf(f).asNondeterministic() ordering.)
+        # Conf values are compared case-insensitively: `SET conf=True` stores
+        # the literal "True", which would otherwise silently disable
+        # transpilation (or mis-trigger the ANSI warning below).
+        def _conf_is_true(key: str) -> bool:
+            if session is None:
+                return False
+            value = session.conf.get(key)
+            return value is not None and value.lower() == "true"
+
         transpile_enabled = (
-            False
-            if session is None
-            else (
-                deterministic
-                and evalType == PythonEvalType.SQL_BATCHED_UDF
-                and session.conf.get("spark.sql.experimental.optimizer.transpilePyUDFs") == "true"
-            )
+            deterministic
+            and evalType == PythonEvalType.SQL_BATCHED_UDF
+            and _conf_is_true("spark.sql.experimental.optimizer.transpilePyUDFs")
         )
-        ansi_enabled = (
-            False if session is None else session.conf.get("spark.sql.ansi.enabled") == "true"
-        )
+        ansi_enabled = _conf_is_true("spark.sql.ansi.enabled")
         # Transpilation only attempts to reproduce ANSI-mode Spark SQL semantics
         # (no silent integer overflow, divide-by-zero raises, etc.). Running it
         # against non-ANSI Spark would balloon the test matrix we'd have to
@@ -481,7 +485,9 @@ class UserDefinedFunction:
             self._judf_placeholder = self._create_judf(self.func)
         return self._judf_placeholder
 
-    def _create_judf(self, func: Callable[..., Any]) -> "JavaObject":
+    def _create_judf(
+        self, func: Callable[..., Any], include_transpiled: bool = True
+    ) -> "JavaObject":
         from pyspark.sql import SparkSession
         from pyspark.sql.classic.column import _to_java_column_opt
 
@@ -491,14 +497,16 @@ class UserDefinedFunction:
         wrapped_func = _wrap_function(sc, func, self.returnType)
         jdt = spark._jsparkSession.parseDataType(self.returnType.json())
         assert sc._jvm is not None
+        transpiled = self.transpiled if include_transpiled else []
+        input_categories = self._transpiled_input_categories if include_transpiled else []
         judf = getattr(sc._jvm, "org.apache.spark.sql.execution.python.UserDefinedPythonFunction")(
             self._name,
             wrapped_func,
             jdt,
             self.evalType,
             self.deterministic,
-            map(_to_java_column_opt, self.transpiled),
-            self._transpiled_input_categories,
+            map(_to_java_column_opt, transpiled),
+            input_categories,
         )
         return judf
 
@@ -580,7 +588,11 @@ class UserDefinedFunction:
                     return profiler.profile(f, *args, **kwargs)
 
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
-                judf = self._create_judf(func)
+                # Profiling requires the Python function to actually execute,
+                # and the transpiled path never runs it (it also produces a
+                # TranspiledPythonUDF, which has no resultId for the profiler
+                # to key on). Build this call's judf without transpiled options.
+                judf = self._create_judf(func, include_transpiled=False)
                 jUDFExpr = judf.builderWithColumns(_to_seq(sc, jcols))
                 jPythonUDF = judf.fromUDFExpr(jUDFExpr)
                 id = jUDFExpr.resultId().id()
@@ -602,7 +614,9 @@ class UserDefinedFunction:
                     )
 
                 func.__signature__ = inspect.signature(f)  # type: ignore[attr-defined]
-                judf = self._create_judf(func)
+                # See the profiler branch above: no transpiled options while
+                # profiling, since only the interpreted path runs the function.
+                judf = self._create_judf(func, include_transpiled=False)
                 jUDFExpr = judf.builderWithColumns(_to_seq(sc, jcols))
                 jPythonUDF = judf.fromUDFExpr(jUDFExpr)
                 id = jUDFExpr.resultId().id()

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -275,6 +275,7 @@ class UserDefinedFunction:
                 warnings.warn(f"Exception transpiling UDF {func}: {e}")
                 self.transpiled = []
                 self._transpiled_param_names = []
+                self._transpiled_input_categories = []
 
     @staticmethod
     def _check_return_type(returnType: DataType, evalType: int) -> None:

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveTranspiledPythonUDFOptions.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.catalyst.expressions.TranspiledPythonUDF
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreePattern.TRANSPILED_PYTHON_UDF
-import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, NumericType, StringType}
+import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, DecimalType, NumericType, StringType}
 
 /**
  * Prunes the per-input-type options carried by a [[TranspiledPythonUDF]] down to those whose
@@ -69,6 +69,16 @@ object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
   // bytes/BinaryType column is tagged "binary" instead, so the string lowerings
   // (e.g. `repeat`) never see it. Empty categories means "no restriction", so the
   // option is kept.
+  //
+  // Two deliberate exclusions keep the transpiled semantics faithful to Python:
+  // - DecimalType is NOT "numeric": Python receives decimal.Decimal objects,
+  //   which raise TypeError when mixed with float literals and carry different
+  //   precision semantics than Spark's decimal arithmetic, so decimal columns
+  //   fall back to interpreted Python.
+  // - "string" requires the default UTF8_BINARY collation: under a non-binary
+  //   collation (e.g. UTF8_LCASE) Spark's `=`/`<`/`concat` follow collation
+  //   rules while Python compares codepoints, so `'abc' == 'ABC'` would return
+  //   true where Python returns False.
   private def optionMatchesTypes(categories: Seq[String], argTypes: Seq[DataType]): Boolean = {
     if (categories.isEmpty) {
       true
@@ -76,8 +86,8 @@ object ResolveTranspiledPythonUDFOptions extends Rule[LogicalPlan] {
       false
     } else {
       categories.zip(argTypes).forall {
-        case ("numeric", dt) => dt.isInstanceOf[NumericType]
-        case ("string", dt) => dt.isInstanceOf[StringType]
+        case ("numeric", dt) => dt.isInstanceOf[NumericType] && !dt.isInstanceOf[DecimalType]
+        case ("string", st: StringType) => st.isUTF8BinaryCollation
         case ("bool", dt) => dt.isInstanceOf[BooleanType]
         case ("binary", dt) => dt.isInstanceOf[BinaryType]
         case _ => false

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/CoercesExpressionTypes.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/CoercesExpressionTypes.scala
@@ -128,9 +128,7 @@ trait CoercesExpressionTypes extends SQLConfHelper with ResolverMetricTracker {
     withTypeCoercion.withNewChildren(newChildren)
   }
 
-  protected[spark] def runCoercionTransformations(expression: Expression,
-    ansiMode: Boolean): Expression = {
-
+  private def runCoercionTransformations(expression: Expression, ansiMode: Boolean): Expression = {
     val transformations = if (ansiMode) {
       ansiTransformations
     } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Expression.scala
@@ -519,6 +519,9 @@ trait NonSQLExpression extends Expression {
       case a: Attribute => new PrettyAttribute(a)
       case a: Alias => PrettyAttribute(a.sql, a.dataType)
       case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
+      // Render a transpiled UDF like the UDF it wraps (options must not leak
+      // into user-visible strings).
+      case t: TranspiledPythonUDF => PrettyPythonUDF(t.name, t.dataType, t.pythonUDFExpr.children)
     }.toString
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/PythonUDF.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql.catalyst.expressions
 
 import org.apache.spark.SparkException.internalError
 import org.apache.spark.api.python.{PythonEvalType, PythonFunction}
-import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedException
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateFunction
@@ -77,8 +76,7 @@ object PythonUDF {
 }
 
 
-trait PythonFuncExpression extends NonSQLExpression with UserDefinedExpression
-    with Logging { self: Expression =>
+trait PythonFuncExpression extends NonSQLExpression with UserDefinedExpression { self: Expression =>
   def name: String
   def func: PythonFunction
   def evalType: Int

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/Optimizer.scala
@@ -1010,9 +1010,15 @@ object ConvertToCatalyst extends Rule[LogicalPlan] {
     if (!plan.containsPattern(TRANSPILED_PYTHON_UDF)) {
       return plan
     }
-    plan.transformAllExpressionsWithPruning(
+    // Traverse subquery plans too: this batch runs Once, and later rules (e.g.
+    // PullupCorrelatedPredicates) can move expressions from a subquery into the
+    // outer plan, so an Unevaluable TranspiledPythonUDF left inside a subquery
+    // here could otherwise escape and reach execution un-stripped.
+    plan.transformDownWithSubqueriesAndPruning(
       _.containsPattern(TRANSPILED_PYTHON_UDF), ruleId) {
-      case s: TranspiledPythonUDF => applyExpr(s, parentIsUdf = false)
+      case p => p.transformExpressionsWithPruning(_.containsPattern(TRANSPILED_PYTHON_UDF)) {
+        case s: TranspiledPythonUDF => applyExpr(s, parentIsUdf = false)
+      }
     }
   }
 
@@ -1059,8 +1065,12 @@ object ConvertToCatalyst extends Rule[LogicalPlan] {
           s.pythonUDFExpr.mapChildren(applyExpr(_, parentIsUdf = true))
         }
       case _ =>
-        // Not a PythonUDF, just recurse down
-        expression.mapChildren(applyExpr(_, parentIsUdf = false))
+        // Not a TranspiledPythonUDF: recurse down, telling the children whether
+        // this node is itself a scalar Python UDF so a transpiled child can
+        // preserve the UDF batch pipeline (e.g. an outer UDF that could not be
+        // transpiled wrapping one that could).
+        expression.mapChildren(
+          applyExpr(_, parentIsUdf = isScalarPythonUDF(expression)))
     }
   }
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/package.scala
@@ -129,6 +129,11 @@ package object util extends Logging {
     case c: Cast if !c.containsTag(Cast.USER_SPECIFIED_CAST) =>
       PrettyAttribute(usePrettyExpression(c.child, shouldTrimTempResolvedColumn).sql, c.dataType)
     case p: PythonFuncExpression => PrettyPythonUDF(p.name, p.dataType, p.children)
+    // Present a transpiled UDF exactly like the UDF it wraps, so auto-generated
+    // column names stay `f(a)` whether or not transpilation engages (the node
+    // carries the rewrite options as extra children, which must not leak into
+    // user-visible names).
+    case t: TranspiledPythonUDF => PrettyPythonUDF(t.name, t.dataType, t.pythonUDFExpr.children)
   }
 
   def quoteIdentifier(name: String): String = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -116,8 +116,16 @@ case class UserDefinedPythonFunction(
     // is `optionInputCategories.nonEmpty`); an empty or mismatched categories
     // list would leave a type-invalid option to fail CheckAnalysis instead of
     // falling back. If the two lists don't line up, skip transpilation.
+    // A call-site arity mismatch (user passed more or fewer args than the UDF's
+    // parameters) must fall back to the plain Python UDF so the standard runtime
+    // TypeError surfaces. Each option's category list has exactly one entry per
+    // public parameter, so a length mismatch against the bound children detects
+    // both directions: too few args would otherwise trip the placeholder bounds
+    // check below as a misleading "internal error", and too many args on a
+    // zero/fewer-param UDF would otherwise silently succeed where Python raises.
     if (transpiledExprsForUse.nonEmpty &&
-        optionInputTypesForUse.length == transpiledExprsForUse.length) {
+        optionInputTypesForUse.length == transpiledExprsForUse.length &&
+        optionInputTypesForUse.forall(_.length == e.length)) {
       val udfChildren = udfExpr.children.toArray
       // Resolve the `_udf_param_N` placeholders the transpiler emits into the bound
       // UDF arguments. Apply this ONLY to the transpiled options -- never to

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/python/UserDefinedPythonFunction.scala
@@ -118,9 +118,12 @@ case class UserDefinedPythonFunction(
     // falling back. If the two lists don't line up, skip transpilation.
     if (transpiledExprsForUse.nonEmpty &&
         optionInputTypesForUse.length == transpiledExprsForUse.length) {
-      val tpu =
-        TranspiledPythonUDF(name, udfExpr, transpiledExprsForUse, optionInputTypesForUse)
-      // Resolve the UDF parameters to match the original UDF children
+      val udfChildren = udfExpr.children.toArray
+      // Resolve the `_udf_param_N` placeholders the transpiler emits into the bound
+      // UDF arguments. Apply this ONLY to the transpiled options -- never to
+      // `udfExpr` itself, whose children are the user's argument expressions. A user
+      // column literally named `_udf_param_N` passed as an argument must not be
+      // rewritten, so we leave `udfExpr` untouched.
       def resolveUDFParams(expression: Expression, children: Array[Expression]): Expression = {
         expression match {
           case UnresolvedAttribute(nameParts)
@@ -139,7 +142,8 @@ case class UserDefinedPythonFunction(
             expression.mapChildren(resolveUDFParams(_, children))
         }
       }
-      resolveUDFParams(tpu, udfExpr.children.toArray)
+      val resolvedOptions = transpiledExprsForUse.map(resolveUDFParams(_, udfChildren))
+      TranspiledPythonUDF(name, udfExpr, resolvedOptions, optionInputTypesForUse)
     } else {
       udfExpr
     }

--- a/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/IntegratedUDFTestUtils.scala
@@ -444,8 +444,7 @@ object IntegratedUDFTestUtils extends SQLHelper {
       evalType: Int,
       udfDeterministic: Boolean,
       resultId: ExprId)
-    extends PythonUDF(name, func, dataType, children, evalType, udfDeterministic,
-      resultId = resultId) {
+    extends PythonUDF(name, func, dataType, children, evalType, udfDeterministic, resultId) {
 
     def this(pudf: PythonUDF) = {
       this(pudf.name, pudf.func, pudf.dataType, pudf.children,


### PR DESCRIPTION
## Summary

This PR adds comprehensive guards to the Python UDF transpiler to prevent silent semantic divergences between Python and Spark SQL. When the transpiler detects patterns that would produce different results in Spark than in Python, it now falls back to interpreted Python execution instead of silently diverging.

## Key Changes

### Python UDF Transpiler Guards (`python/pyspark/sql/transpile.py`)

- **Branch type mismatch detection**: Added `_safe_category()` method to classify if/else branch types (seeing through `ast.Return` wrappers). When branches produce different Spark categories (e.g., numeric vs string), the transpiler now refuses to lower to CASE WHEN, which would fail ANSI type analysis or coerce incorrectly.

- **Cross-category equality guard**: Modified `_lower_eq()` to detect when `==`/`!=` operands have incompatible categories (e.g., `x == True` on a numeric column). These cases now fall back to interpreted Python instead of failing analysis or silently coercing.

- **Literal None in boolean operators**: Added detection for literal `None` operands in `and`/`or` expressions. Python's short-circuit semantics (`None and x` returns `None`) differ from Spark's three-valued logic, so these now force fallback.

- **Decorated function detection**: Added check for `functools.wraps`-decorated functions. Since `inspect.getsource()` follows `__wrapped__`, transpiling would execute the wrapped function's source while the interpreter runs the wrapper, causing silent wrong results.

- **Plain `self` parameter handling**: A plain function whose first parameter is named `self` is no longer mistaken for a bound `__call__` method; stripping it previously emitted `_udf_param_-1` and threw an AnalysisException at call construction.

- **Improved source extraction**: Enhanced `_get_src_ast_from_func()` to handle edge cases where source cannot be obtained (REPL, stdin, builtins) without raising UnboundLocalError.

### UDF Configuration and Call Handling (`python/pyspark/sql/udf.py`)

- **Case-insensitive config parsing**: Fixed config value comparison to be case-insensitive. `SET conf=True` stores the literal string "True", which previously silently disabled transpilation (and mis-triggered the ANSI warning).

- **Profiler compatibility**: The profiler and memory-profiler paths now build their UDF without transpiled options -- profiling requires the Python function to actually execute, and the substituted expression has no `resultId` for the profiler to key on.

### Catalyst Optimizer Rules (`sql/catalyst/.../optimizer/Optimizer.scala`)

- **Subquery traversal**: `ConvertToCatalyst` now traverses subquery plans in addition to the main plan. The batch runs Once, and later rules can pull expressions out of subqueries, so a `TranspiledPythonUDF` left inside a subquery could otherwise reach execution un-stripped.

- **Pipelining propagation**: the recursion now tells children when their parent is a scalar Python UDF, so UDF-chain pipelining is preserved under a non-transpiled outer UDF.

### Input Type Category Pruning (`sql/catalyst/.../analysis/ResolveTranspiledPythonUDFOptions.scala`)

- **DecimalType exclusion**: `DecimalType` no longer matches the numeric category. Python's `decimal.Decimal` objects raise TypeError when mixed with float literals, so decimal columns fall back to interpreted Python.

- **Collation guard**: the string category requires the default UTF8_BINARY collation. Under UTF8_LCASE, `'abc' = 'ABC'` is true while Python's `==` is False.

### Scala UDF Builder (`sql/core/.../python/UserDefinedPythonFunction.scala`)

- **Arity validation**: options are dropped when input category list lengths don't match the number of bound arguments, so wrong-arity calls surface the standard Python TypeError instead of being silently absorbed (zero-param case) or raising a misleading "internal error" AnalysisException (too-few-args case).

### Presentation (`sql/catalyst/.../util/package.scala`, `Expression.scala`)

- **Column name preservation**: auto-generated column names stay `f(a)` when transpilation engages; the `TranspiledPythonUDF` wrapper previously leaked into schema names as `transpiledpythonudf(f(a), CAST(...))`.

### CI

- Fixed the ruff-format failures that were failing the lint job, and made the `RUN_HYPOTHESIS` gate value-based: `build_and_test.yml` always sets the env var (to "true"/"false"), so the previous presence-based gate would have run the very slow hypothesis suite on every PySpark job.

## Test Coverage

Added regression tests covering: mismatched branch types in if/ternary expressions, cross-category equality, boolean-returning vs numeric branches, plain `self` parameters, `functools.wraps`-decorated functions, literal `None` in boolean operators, auto-generated column name preservation, arity mismatch error handling, decimal input fallback, collated string fallback, and a value-based `RUN_HYPOTHESIS` gating smoke test.

Updated existing test expectations where the new guards correctly prevent divergences (e.g., `x == "5"` on a long column now matches Python's cross-type equality instead of Spark's coercion).

Verified locally: `sbt -Phive package`, `test_udf_transpile_unit` / `test_udf_transpile_parity` / hypothesis suites, `ConvertToCatalystSuite` + `ResolveTranspiledPythonUDFOptionsSuite` (16/16), CI-equivalent ruff checks, mypy clean on feature files.

https://claude.ai/code/session_01GibQDjXJ5jmUhA1yXAxFUr