### PR TITLE
[SQL] LDAP Thriftserver improvement

### DIFF
--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -96,7 +96,7 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
   // Builds the list of LDAP principals (Distinguished Names) to attempt binding with for the
   // given user. The user-supplied value is escaped with {@link Rdn#escapeValue} before it is
   // placed into a DN so that LDAP special characters including ',', '=', '+', '<', '>', etc.
-  // cannot alter the DN structure. See RFC-2253
+  // cannot alter the DN structure. See RFC-2253.
   // Visible for testing.
   List<String> createCandidatePrincipals(String user) {
     String escapedUser = Rdn.escapeValue(user);

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.naming.Context;
 import javax.naming.NamingException;
 import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.Rdn;
 import javax.security.sasl.AuthenticationException;
 
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -39,7 +40,11 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
   private final String userDNPattern;
 
   LdapAuthenticationProviderImpl() {
-    HiveConf conf = new HiveConf();
+    this(new HiveConf());
+  }
+
+  // Visible for testing.
+  LdapAuthenticationProviderImpl(HiveConf conf) {
     ldapURL = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_URL);
     baseDN = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_BASEDN);
     ldapDomain = conf.getVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_DOMAIN);
@@ -62,24 +67,7 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
     }
 
     // setup the security principal
-    List<String> candidatePrincipals = new ArrayList<>();
-    if (Utils.isBlank(userDNPattern)) {
-      if (Utils.isNotBlank(baseDN)) {
-        String pattern = "uid=" + user + "," + baseDN;
-        candidatePrincipals.add(pattern);
-      }
-    } else {
-      String[] patterns = userDNPattern.split(":");
-      for (String pattern : patterns) {
-        if (pattern.contains(",") && pattern.contains("=")) {
-          candidatePrincipals.add(pattern.replaceAll("%s", user));
-        }
-      }
-    }
-
-    if (candidatePrincipals.isEmpty()) {
-      candidatePrincipals = Collections.singletonList(user);
-    }
+    List<String> candidatePrincipals = createCandidatePrincipals(user);
 
     for (Iterator<String> iterator = candidatePrincipals.iterator(); iterator.hasNext();) {
       String principal = iterator.next();
@@ -103,6 +91,37 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
         }
       }
     }
+  }
+
+  // Builds the list of LDAP principals (Distinguished Names) to attempt binding with for the
+  // given user. The user-supplied value is escaped with {@link Rdn#escapeValue} before it is
+  // placed into a DN so that LDAP special characters (',', '=', '+', '<', '>', '#', ';', '"',
+  // '\\' and leading/trailing spaces) cannot alter the DN structure. See RFC 2253 and CWE-90.
+  //
+  // Visible for testing.
+  List<String> createCandidatePrincipals(String user) {
+    String escapedUser = Rdn.escapeValue(user);
+    List<String> candidatePrincipals = new ArrayList<>();
+    if (Utils.isBlank(userDNPattern)) {
+      if (Utils.isNotBlank(baseDN)) {
+        String pattern = "uid=" + escapedUser + "," + baseDN;
+        candidatePrincipals.add(pattern);
+      }
+    } else {
+      String[] patterns = userDNPattern.split(":");
+      for (String pattern : patterns) {
+        if (pattern.contains(",") && pattern.contains("=")) {
+          // Use literal replacement: the escaped user may contain '\\', which would otherwise be
+          // treated as a regex escape by String.replaceAll.
+          candidatePrincipals.add(pattern.replace("%s", escapedUser));
+        }
+      }
+    }
+
+    if (candidatePrincipals.isEmpty()) {
+      candidatePrincipals = Collections.singletonList(user);
+    }
+    return candidatePrincipals;
   }
 
   private boolean hasDomain(String userName) {

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -117,6 +117,7 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
       }
     }
 
+    // If there is no configured pattern or base we accept the raw user in full.
     if (candidatePrincipals.isEmpty()) {
       candidatePrincipals = Collections.singletonList(user);
     }

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -95,9 +95,8 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
 
   // Builds the list of LDAP principals (Distinguished Names) to attempt binding with for the
   // given user. The user-supplied value is escaped with {@link Rdn#escapeValue} before it is
-  // placed into a DN so that LDAP special characters (',', '=', '+', '<', '>', '#', ';', '"',
-  // '\\' and leading/trailing spaces) cannot alter the DN structure. See RFC 2253 and CWE-90.
-  //
+  // placed into a DN so that LDAP special characters including ',', '=', '+', '<', '>', etc.
+  // cannot alter the DN structure. See RFC-2253
   // Visible for testing.
   List<String> createCandidatePrincipals(String user) {
     String escapedUser = Rdn.escapeValue(user);

--- a/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
+++ b/sql/hive-thriftserver/src/main/java/org/apache/hive/service/auth/LdapAuthenticationProviderImpl.java
@@ -117,7 +117,8 @@ public class LdapAuthenticationProviderImpl implements PasswdAuthenticationProvi
       }
     }
 
-    // If there is no configured pattern or base we accept the raw user in full.
+    // If there is no configured pattern or base we accept the raw user in full because there is no
+    // pattern we're trying to safely inject into.
     if (candidatePrincipals.isEmpty()) {
       candidatePrincipals = Collections.singletonList(user);
     }

--- a/sql/hive-thriftserver/src/test/scala/org/apache/hive/service/auth/LdapAuthenticationProviderImplSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/hive/service/auth/LdapAuthenticationProviderImplSuite.scala
@@ -54,7 +54,7 @@ class LdapAuthenticationProviderImplSuite extends SparkFunSuite {
       dns("uid=alice,ou=users,dc=example,dc=com"))
   }
 
-  test("SPARK: LDAP special characters in the username are escaped for the baseDN pattern") {
+  test("LDAP special characters in the username are escaped for the baseDN pattern") {
     val provider = newProvider(baseDN = "ou=users,dc=example,dc=com")
     // Without escaping this would be "uid=admin,ou=Admins,ou=users,dc=example,dc=com", letting
     // the attacker bind as a different DN (authentication bypass / impersonation).
@@ -62,19 +62,19 @@ class LdapAuthenticationProviderImplSuite extends SparkFunSuite {
       dns("uid=admin\\,ou\\=Admins,ou=users,dc=example,dc=com"))
   }
 
-  test("SPARK: full DN structure manipulation is neutralized for the baseDN pattern") {
+  test("full DN structure manipulation is neutralized for the baseDN pattern") {
     val provider = newProvider(baseDN = "ou=users,dc=example,dc=com")
     assert(principals(provider, "attacker,ou=Admins,dc=example,dc=com") ===
       dns("uid=attacker\\,ou\\=Admins\\,dc\\=example\\,dc\\=com,ou=users,dc=example,dc=com"))
   }
 
-  test("SPARK: LDAP special characters in the username are escaped for userDNPattern") {
+  test("LDAP special characters in the username are escaped for userDNPattern") {
     val provider = newProvider(userDNPattern = "uid=%s,ou=service,dc=example,dc=com")
     assert(principals(provider, "admin,ou=Admins") ===
       dns("uid=admin\\,ou\\=Admins,ou=service,dc=example,dc=com"))
   }
 
-  test("SPARK: multiple userDNPatterns are all escaped") {
+  test("multiple userDNPatterns are all escaped") {
     val provider = newProvider(
       userDNPattern = "uid=%s,ou=service,dc=example,dc=com:cn=%s,ou=people,dc=example,dc=com")
     assert(principals(provider, "a+b,c") === dns(
@@ -82,7 +82,7 @@ class LdapAuthenticationProviderImplSuite extends SparkFunSuite {
       "cn=a\\+b\\,c,ou=people,dc=example,dc=com"))
   }
 
-  test("SPARK: escaped backslashes are inserted literally (no regex replacement)") {
+  test("escaped backslashes are inserted literally (no regex replacement)") {
     // The escaped value contains a backslash; String.replaceAll would treat it as a regex escape
     // and either throw or corrupt the output. Verify literal insertion.
     val provider = newProvider(userDNPattern = "uid=%s,ou=service,dc=example,dc=com")

--- a/sql/hive-thriftserver/src/test/scala/org/apache/hive/service/auth/LdapAuthenticationProviderImplSuite.scala
+++ b/sql/hive-thriftserver/src/test/scala/org/apache/hive/service/auth/LdapAuthenticationProviderImplSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.service.auth
+
+import java.util.{Arrays => JArrays, List => JList}
+
+import org.apache.hadoop.hive.conf.HiveConf
+
+import org.apache.spark.SparkFunSuite
+
+class LdapAuthenticationProviderImplSuite extends SparkFunSuite {
+
+  private def newProvider(
+      baseDN: String = null,
+      userDNPattern: String = null,
+      ldapDomain: String = null): LdapAuthenticationProviderImpl = {
+    val conf = new HiveConf()
+    // Avoid picking up a real LDAP URL from any hive-site.xml on the test classpath.
+    conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_URL, "ldap://localhost:389")
+    if (baseDN != null) {
+      conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_BASEDN, baseDN)
+    }
+    if (userDNPattern != null) {
+      conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_USERDNPATTERN, userDNPattern)
+    }
+    if (ldapDomain != null) {
+      conf.setVar(HiveConf.ConfVars.HIVE_SERVER2_PLAIN_LDAP_DOMAIN, ldapDomain)
+    }
+    new LdapAuthenticationProviderImpl(conf)
+  }
+
+  private def principals(provider: LdapAuthenticationProviderImpl, user: String): JList[String] =
+    provider.createCandidatePrincipals(user)
+
+  private def dns(values: String*): JList[String] = JArrays.asList(values: _*)
+
+  test("legitimate usernames are left untouched when building the DN") {
+    val provider = newProvider(baseDN = "ou=users,dc=example,dc=com")
+    assert(principals(provider, "alice") ===
+      dns("uid=alice,ou=users,dc=example,dc=com"))
+  }
+
+  test("SPARK: LDAP special characters in the username are escaped for the baseDN pattern") {
+    val provider = newProvider(baseDN = "ou=users,dc=example,dc=com")
+    // Without escaping this would be "uid=admin,ou=Admins,ou=users,dc=example,dc=com", letting
+    // the attacker bind as a different DN (authentication bypass / impersonation).
+    assert(principals(provider, "admin,ou=Admins") ===
+      dns("uid=admin\\,ou\\=Admins,ou=users,dc=example,dc=com"))
+  }
+
+  test("SPARK: full DN structure manipulation is neutralized for the baseDN pattern") {
+    val provider = newProvider(baseDN = "ou=users,dc=example,dc=com")
+    assert(principals(provider, "attacker,ou=Admins,dc=example,dc=com") ===
+      dns("uid=attacker\\,ou\\=Admins\\,dc\\=example\\,dc\\=com,ou=users,dc=example,dc=com"))
+  }
+
+  test("SPARK: LDAP special characters in the username are escaped for userDNPattern") {
+    val provider = newProvider(userDNPattern = "uid=%s,ou=service,dc=example,dc=com")
+    assert(principals(provider, "admin,ou=Admins") ===
+      dns("uid=admin\\,ou\\=Admins,ou=service,dc=example,dc=com"))
+  }
+
+  test("SPARK: multiple userDNPatterns are all escaped") {
+    val provider = newProvider(
+      userDNPattern = "uid=%s,ou=service,dc=example,dc=com:cn=%s,ou=people,dc=example,dc=com")
+    assert(principals(provider, "a+b,c") === dns(
+      "uid=a\\+b\\,c,ou=service,dc=example,dc=com",
+      "cn=a\\+b\\,c,ou=people,dc=example,dc=com"))
+  }
+
+  test("SPARK: escaped backslashes are inserted literally (no regex replacement)") {
+    // The escaped value contains a backslash; String.replaceAll would treat it as a regex escape
+    // and either throw or corrupt the output. Verify literal insertion.
+    val provider = newProvider(userDNPattern = "uid=%s,ou=service,dc=example,dc=com")
+    assert(principals(provider, "a\\b") ===
+      dns("uid=a\\\\b,ou=service,dc=example,dc=com"))
+  }
+
+  test("leading and trailing spaces in the username are escaped") {
+    val provider = newProvider(baseDN = "ou=users,dc=example,dc=com")
+    assert(principals(provider, " alice ") ===
+      dns("uid=\\ alice\\ ,ou=users,dc=example,dc=com"))
+  }
+}


### PR DESCRIPTION


### What changes were proposed in this pull request?

Improve DN construction in the Hive ThriftServer LDAP provider by escaping user-supplied values to avoid misconfiguration. 

### Why are the changes needed?

Built in LDAP RFC implementation is more robust.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

Adds unit tests for the DN construction.



### Was this patch authored or co-authored using generative AI tooling?

Primarily written by claude 4.8
