### PR TITLE
[SPARK-55206][PYTHON][SQL] Harden Python UDF transpilation safety checks

### DIFF
--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -914,11 +914,16 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             self.assertIsNone(result[0], "interpreted fallback nulls the mismatch")
 
     def test_udf_transpile_falls_back_for_cross_category_return_cast(self):
-        # Per-variant guard: a binary-typed body cannot be cast to a numeric
-        # return type (and a boolean body cannot be cast to binary) -- the
-        # unresolvable Cast would fail analysis instead of falling back. A
-        # binary body cast to string stays transpilable (valid ANSI cast).
+        # Per-variant guard: the body category must MATCH the declared return
+        # type's category. Un-castable combos (binary body -> numeric return,
+        # boolean body -> binary return) would fail analysis outright, and
+        # analysis-valid cross-category casts (string -> long, numeric ->
+        # boolean, anything -> decimal) diverge from the interpreted path,
+        # which nulls type-mismatched results instead of casting -- e.g.
+        # `def f(s: str): return s` declared LongType() would return 123 for
+        # '123' (or raise CAST_INVALID_INPUT) where interpreted returns NULL.
         import warnings as _warnings
+        from pyspark.sql.types import DecimalType
 
         def bytes_to_long(x: bytes):
             return x
@@ -926,19 +931,32 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
         def bool_to_binary(x):
             return (x > 0) if x is not None else None
 
+        def str_ident(s: str):
+            return s
+
+        def plus_one(x):
+            return x + 1
+
         with self.sql_conf(_TRANSPILE_ON):
             for func, rt, label in (
                 (bytes_to_long, LongType(), "binary body -> numeric return"),
                 (bool_to_binary, BinaryType(), "boolean body -> binary return"),
+                (bytes_to_long, StringType(), "binary body -> string return"),
+                (str_ident, LongType(), "string body -> numeric return"),
+                (plus_one, BooleanType(), "numeric body -> boolean return"),
+                (plus_one, DecimalType(10, 2), "numeric body -> decimal return"),
             ):
                 with _warnings.catch_warnings(record=True):
                     _warnings.simplefilter("always")
                     pudf = UserDefinedFunction(func, rt)
                 self.assertEqual([], pudf.transpiled, f"{label} must not transpile")
+            # Interpreted execution of the Codex-flagged example: NULL, not a
+            # cast. (The transpiled cast would have returned 123.)
             with _warnings.catch_warnings(record=True):
                 _warnings.simplefilter("always")
-                str_ok = UserDefinedFunction(bytes_to_long, StringType())
-            self.assertTrue(str_ok.transpiled, "binary body -> string return is castable")
+                str_long = UserDefinedFunction(str_ident, LongType())
+            df = self.spark.createDataFrame([("123",)], "s string")
+            self.assertIsNone(df.select(str_long("s")).first()[0])
 
     def test_udf_transpile_falls_back_for_non_numeric_unary(self):
         # Unary +/- only lower for numeric operands: Python raises TypeError
@@ -975,18 +993,20 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
 
         class PickSelf:
             def __call__(self, x):
-                return self if x is None else x
+                return x if x is not None else self
 
         with self.sql_conf(_TRANSPILE_ON):
             with _warnings.catch_warnings(record=True):
                 _warnings.simplefilter("always")
                 pudf = UserDefinedFunction(PickSelf(), LongType())
             self.assertEqual([], pudf.transpiled, "`self` reference must not transpile")
-            df = self.spark.createDataFrame([(2,), (None,)], "a long")
+            # Interpreted execution still works (previously the call itself
+            # raised). Only non-null rows are exercised: a row that RETURNS
+            # `self` would fail JVM-side unpickling of the instance, which is
+            # interpreted-UDF behavior unrelated to this guard.
+            df = self.spark.createDataFrame([(2,), (7,)], "a long")
             results = [r[0] for r in df.select(pudf("a")).collect()]
-            # Interpreted execution: x for the non-null row; the returned
-            # instance for the null row is type-mismatched and converts to null.
-            self.assertEqual(results, [2, None])
+            self.assertEqual(results, [2, 7])
 
     def test_udf_transpile_preserves_auto_column_name(self):
         # The auto-generated column name must stay `f(a)` whether or not the
@@ -1042,7 +1062,10 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             return x + 1.5
 
         with self.sql_conf(_TRANSPILE_ON):
-            pudf = UserDefinedFunction(add_half, StringType())
+            # DoubleType: the return type must category-match the numeric body
+            # for the option to be emitted (a string return type would itself
+            # force a fallback before the decimal-input pruning under test).
+            pudf = UserDefinedFunction(add_half, DoubleType())
             self.assertTrue(pudf.transpiled, "numeric option should still be produced")
             df = self.spark.sql("SELECT CAST(1.0 AS DECIMAL(10,2)) AS d")
             with self.assertRaises(PythonException):

--- a/python/pyspark/sql/tests/test_udf_transpile_unit.py
+++ b/python/pyspark/sql/tests/test_udf_transpile_unit.py
@@ -886,6 +886,108 @@ class UDFTranspileUnitTests(ReusedSQLTestCase):
             [result] = df.select(pudf("a")).collect()
             self.assertIsNone(result[0])
 
+    def test_udf_transpile_falls_back_for_uncastable_return_type(self):
+        # The lowered expression is cast to the declared return type; a return
+        # type no atomic lowering can be cast to (arrays, maps, datetimes, ...)
+        # would make that Cast fail CheckAnalysis and break the whole query
+        # (the options are children of TranspiledPythonUDF), so such UDFs must
+        # fall back at construction instead. Interpreted execution still works
+        # (the pickled-UDF converter nulls the type-mismatched results).
+        import warnings as _warnings
+        from pyspark.sql.types import ArrayType, TimestampType
+
+        plus_one = lambda x: x + 1  # noqa: E731
+        with self.sql_conf(_TRANSPILE_ON):
+            for rt in (ArrayType(LongType()), TimestampType()):
+                with _warnings.catch_warnings(record=True):
+                    _warnings.simplefilter("always")
+                    pudf = UserDefinedFunction(plus_one, rt)
+                self.assertEqual([], pudf.transpiled, f"return type {rt} must not transpile")
+            # Interpreted execution keeps working; an int result for an array
+            # return type is nulled by the pickled-UDF converter. (Timestamp
+            # is not exercised here: its converter accepts ints as micros.)
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                array_udf = UserDefinedFunction(plus_one, ArrayType(LongType()))
+            df = self.spark.createDataFrame([Row(a=1)])
+            [result] = df.select(array_udf("a")).collect()
+            self.assertIsNone(result[0], "interpreted fallback nulls the mismatch")
+
+    def test_udf_transpile_falls_back_for_cross_category_return_cast(self):
+        # Per-variant guard: a binary-typed body cannot be cast to a numeric
+        # return type (and a boolean body cannot be cast to binary) -- the
+        # unresolvable Cast would fail analysis instead of falling back. A
+        # binary body cast to string stays transpilable (valid ANSI cast).
+        import warnings as _warnings
+
+        def bytes_to_long(x: bytes):
+            return x
+
+        def bool_to_binary(x):
+            return (x > 0) if x is not None else None
+
+        with self.sql_conf(_TRANSPILE_ON):
+            for func, rt, label in (
+                (bytes_to_long, LongType(), "binary body -> numeric return"),
+                (bool_to_binary, BinaryType(), "boolean body -> binary return"),
+            ):
+                with _warnings.catch_warnings(record=True):
+                    _warnings.simplefilter("always")
+                    pudf = UserDefinedFunction(func, rt)
+                self.assertEqual([], pudf.transpiled, f"{label} must not transpile")
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                str_ok = UserDefinedFunction(bytes_to_long, StringType())
+            self.assertTrue(str_ok.transpiled, "binary body -> string return is castable")
+
+    def test_udf_transpile_falls_back_for_non_numeric_unary(self):
+        # Unary +/- only lower for numeric operands: Python raises TypeError
+        # on `+s`/`-s` for strings while Spark's ANSI string promotion would
+        # silently coerce (`-'5'` -> -5.0), and `-x` on a boolean would fail
+        # analysis outright rather than fall back.
+        import warnings as _warnings
+
+        def neg_str(s: str):
+            return -s
+
+        def pos_str(s: str):
+            return +s
+
+        def neg_bool(x: bool):
+            return -x
+
+        with self.sql_conf(_TRANSPILE_ON):
+            for func in (neg_str, pos_str, neg_bool):
+                with _warnings.catch_warnings(record=True):
+                    _warnings.simplefilter("always")
+                    pudf = UserDefinedFunction(func, LongType())
+                self.assertEqual([], pudf.transpiled, f"{func.__name__} must not transpile")
+        # Numeric unary still lowers and matches Python.
+        neg = lambda x: -x  # noqa: E731
+        self.assertEqual(self._vals(neg, LongType(), "a long", [(5,), (-3,)]), [-5, 3])
+
+    def test_udf_transpile_falls_back_for_self_reference(self):
+        # A __call__ body that references bare `self` has no column
+        # equivalent; the offset scheme previously emitted `_udf_param_-1`,
+        # which the JVM builder rejected with an AnalysisException at call
+        # construction instead of falling back to interpreted Python.
+        import warnings as _warnings
+
+        class PickSelf:
+            def __call__(self, x):
+                return self if x is None else x
+
+        with self.sql_conf(_TRANSPILE_ON):
+            with _warnings.catch_warnings(record=True):
+                _warnings.simplefilter("always")
+                pudf = UserDefinedFunction(PickSelf(), LongType())
+            self.assertEqual([], pudf.transpiled, "`self` reference must not transpile")
+            df = self.spark.createDataFrame([(2,), (None,)], "a long")
+            results = [r[0] for r in df.select(pudf("a")).collect()]
+            # Interpreted execution: x for the non-null row; the returned
+            # instance for the null row is type-mismatched and converts to null.
+            self.assertEqual(results, [2, None])
+
     def test_udf_transpile_preserves_auto_column_name(self):
         # The auto-generated column name must stay `f(a)` whether or not the
         # rewrite engages; the TranspiledPythonUDF wrapper (and its option

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -47,6 +47,7 @@ from pyspark.sql.types import (
     BinaryType,
     BooleanType,
     DataType,
+    DecimalType,
     NumericType,
     StringType,
 )
@@ -737,29 +738,51 @@ class CatalystTranspiler(AbstractTranspiler):
                 "functions with more than one top-level statement are not "
                 "supported by the transpiler"
             )
-        # Refuse variants whose final Cast to the declared return type can
-        # never resolve. The options are type-checked by CheckAnalysis as
-        # children of TranspiledPythonUDF before ConvertToCatalyst could drop
-        # them, so an invalid Cast (e.g. a binary-typed body cast to a numeric
-        # return type) fails the whole query instead of falling back. Under
-        # ANSI: string bodies cast to every allowed return type (string ->
-        # numeric/boolean are runtime-checked but analysis-valid), numeric and
-        # boolean bodies cast to everything except binary, and binary bodies
-        # cast only to string/binary. An unknown category (e.g. a bare None
-        # body) lowers to NULL, which casts to anything.
+        # Refuse variants whose body category does not MATCH the declared
+        # return type's category. Two distinct failure modes hide here:
+        #
+        # * A cast that can never resolve (binary -> numeric, bool -> binary):
+        #   the options are type-checked by CheckAnalysis as children of
+        #   TranspiledPythonUDF before ConvertToCatalyst could drop them, so
+        #   the whole query fails instead of falling back.
+        # * A cast that IS analysis-valid but that the interpreted
+        #   SQL_BATCHED_UDF path never performs: EvaluatePython.makeFromJava
+        #   accepts only the expected JVM types for the declared return type
+        #   and nulls everything else. E.g. `def f(s: str): return s` declared
+        #   LongType() returns NULL interpreted, but a lowered
+        #   cast(string as bigint) would return 123 for '123' (or raise
+        #   CAST_INVALID_INPUT for 'abc') -- a silent divergence.
+        #
+        # So require the strict match: numeric -> non-decimal NumericType
+        # (DecimalType is excluded like it is for inputs: the interpreted
+        # converter accepts only decimal.Decimal results there and nulls the
+        # ints/floats these lowerings produce), string -> StringType, bool ->
+        # BooleanType, binary -> BinaryType. An unknown category (e.g. a bare
+        # None body) lowers to NULL, which every return type accepts as NULL
+        # on both paths. Within-numeric conversions (e.g. a bigint body cast
+        # to a double return type) are intentionally still allowed and
+        # documented as the transpiled-cast behavior pinned by
+        # test_udf_transpile_casts_to_return_type.
         if isinstance(returnType, DataType):
             body_cat = self._safe_category(params, function_body[0])
             cast_ok = (
                 body_cat is None
-                or body_cat == "string"
-                or (body_cat in ("numeric", "bool") and not isinstance(returnType, BinaryType))
-                or (body_cat == "binary" and isinstance(returnType, (StringType, BinaryType)))
+                or (
+                    body_cat == "numeric"
+                    and isinstance(returnType, NumericType)
+                    and not isinstance(returnType, DecimalType)
+                )
+                or (body_cat == "string" and isinstance(returnType, StringType))
+                or (body_cat == "bool" and isinstance(returnType, BooleanType))
+                or (body_cat == "binary" and isinstance(returnType, BinaryType))
             )
             if not cast_ok:
                 raise UnsupportedOperationException(
-                    f"a {body_cat}-typed lowering cannot be cast to the declared "
-                    f"return type {returnType.simpleString()} under ANSI rules; "
-                    "falling back to interpreted Python"
+                    f"a {body_cat}-typed lowering does not match the declared "
+                    f"return type {returnType.simpleString()}; the interpreted "
+                    "path would return NULL where the lowered cast would "
+                    "convert (or fail), so the transpiler falls back to "
+                    "interpreted Python"
                 )
         converted = self._convert_chunk(params, function_body[0])
         # Cast to the declared return type so the rewritten plan reports a
@@ -948,13 +971,14 @@ def _transpile_func(
     try:
         # The transpiler lowers to atomic (numeric/string/boolean/binary)
         # expressions and casts the result to the declared return type. For a
-        # return type no lowering can be cast to (arrays, maps, structs,
-        # datetimes, ...), that Cast can never resolve -- and because the
-        # options ride along as children of TranspiledPythonUDF, an
-        # unresolvable Cast fails the WHOLE query at CheckAnalysis instead of
-        # falling back. Restrict transpilation to return types with a valid
-        # ANSI cast from the lowered categories (the per-variant combinations
-        # are checked in ``_transpile_from_ast``); everything else falls back
+        # return type no lowering can even category-match (arrays, maps,
+        # structs, datetimes, ...), that Cast either never resolves -- and
+        # because the options ride along as children of TranspiledPythonUDF,
+        # an unresolvable Cast fails the WHOLE query at CheckAnalysis instead
+        # of falling back -- or diverges from the interpreted converter, which
+        # nulls type-mismatched results. Restrict transpilation to return
+        # types some lowering can match (the strict per-variant body-category
+        # check lives in ``_transpile_from_ast``); everything else falls back
         # to interpreted Python.
         if isinstance(returnType, str):
             from pyspark.sql.types import _parse_datatype_string

--- a/python/pyspark/sql/transpile.py
+++ b/python/pyspark/sql/transpile.py
@@ -43,6 +43,13 @@ import itertools
 import textwrap
 from pyspark.errors import UnsupportedOperationException
 from pyspark.sql.column import Column
+from pyspark.sql.types import (
+    BinaryType,
+    BooleanType,
+    DataType,
+    NumericType,
+    StringType,
+)
 from pyspark.sql.functions import (
     abs as _abs,
     coalesce,
@@ -174,6 +181,16 @@ class CatalystTranspiler(AbstractTranspiler):
         # would fall through to ``_category``'s numeric catch-all).
         if isinstance(node, ast.Return):
             return self._safe_category(params, node.value)
+        # An if-statement's category is its branches' common category (the
+        # ``_category`` catch-all would mislabel every ``ast.If`` "numeric").
+        # Mismatched branches return None ("can't be pinned down"); the
+        # branch-compatibility check in ``_convert_if_like`` raises for them.
+        if isinstance(node, ast.If):
+            body_c = self._safe_category(params, node.body[0]) if node.body else None
+            else_c = self._safe_category(params, node.orelse[0]) if node.orelse else None
+            if body_c is not None and else_c is not None and body_c != else_c:
+                return None
+            return body_c if body_c is not None else else_c
         if isinstance(node, ast.Constant) and node.value is None:
             return None
         # Comparisons / ``not`` / boolean ops produce a boolean column; classify
@@ -446,11 +463,27 @@ class CatalystTranspiler(AbstractTranspiler):
                         "and the UDF falls back to interpreted Python"
                     )
                 return coalesce(self._convert_chunk(params, operand).__invert__(), lit(True))
-            case ast.UnaryOp(op=ast.USub(), operand=operand):
-                # `-x` -- handle both literal negative ints (USub on a
-                # Constant) and runtime negation of a column.
-                return self._convert_chunk(params, operand).__neg__()
-            case ast.UnaryOp(op=ast.UAdd(), operand=operand):
+            case ast.UnaryOp(op=(ast.USub() | ast.UAdd()) as op, operand=operand):
+                # `-x` / `+x` -- like the binary arithmetic operators, only
+                # lower for numeric operands. Python raises TypeError for
+                # unary +/- on strings, but Spark's ANSI string promotion
+                # would silently coerce the string to double (`-'5'` ->
+                # -5.0), and a boolean operand emits UnaryMinus(bool), which
+                # fails CheckAnalysis outright -- breaking the query instead
+                # of falling back, since the option is type-checked as a
+                # child of TranspiledPythonUDF before ConvertToCatalyst can
+                # drop it. Fail closed for every non-numeric category.
+                if self._category(params, operand) != "numeric":
+                    raise UnsupportedOperationException(
+                        "unary `+`/`-` is only supported for numeric operands "
+                        "(Python raises TypeError on strings, and Spark would "
+                        "coerce or fail analysis); the transpiler falls back "
+                        "to interpreted Python"
+                    )
+                if isinstance(op, ast.USub):
+                    # Handles both literal negative ints (USub on a Constant)
+                    # and runtime negation of a column.
+                    return self._convert_chunk(params, operand).__neg__()
                 # `+x` -- identity, kept for symmetry with USub.
                 return self._convert_chunk(params, operand)
             case ast.BoolOp(op=op, values=values):
@@ -655,6 +688,19 @@ class CatalystTranspiler(AbstractTranspiler):
                     param_index = params.index(name)
                     # Special hack for self on callables
                     if params[0] == "self":
+                        # A body that references the receiver itself (e.g.
+                        # ``return self``) has no column equivalent: ``self``
+                        # is not an argument at the call site, and offsetting
+                        # would emit ``_udf_param_-1``, which the JVM builder
+                        # rejects with an AnalysisException at call
+                        # construction instead of falling back. Refuse so the
+                        # UDF stays interpreted.
+                        if name == "self":
+                            raise UnsupportedOperationException(
+                                "references to `self` in a callable's body "
+                                "are not supported by the transpiler; falling "
+                                "back to interpreted Python"
+                            )
                         param_index -= 1
                     return col(f"_udf_param_{param_index}")
                 else:
@@ -691,6 +737,30 @@ class CatalystTranspiler(AbstractTranspiler):
                 "functions with more than one top-level statement are not "
                 "supported by the transpiler"
             )
+        # Refuse variants whose final Cast to the declared return type can
+        # never resolve. The options are type-checked by CheckAnalysis as
+        # children of TranspiledPythonUDF before ConvertToCatalyst could drop
+        # them, so an invalid Cast (e.g. a binary-typed body cast to a numeric
+        # return type) fails the whole query instead of falling back. Under
+        # ANSI: string bodies cast to every allowed return type (string ->
+        # numeric/boolean are runtime-checked but analysis-valid), numeric and
+        # boolean bodies cast to everything except binary, and binary bodies
+        # cast only to string/binary. An unknown category (e.g. a bare None
+        # body) lowers to NULL, which casts to anything.
+        if isinstance(returnType, DataType):
+            body_cat = self._safe_category(params, function_body[0])
+            cast_ok = (
+                body_cat is None
+                or body_cat == "string"
+                or (body_cat in ("numeric", "bool") and not isinstance(returnType, BinaryType))
+                or (body_cat == "binary" and isinstance(returnType, (StringType, BinaryType)))
+            )
+            if not cast_ok:
+                raise UnsupportedOperationException(
+                    f"a {body_cat}-typed lowering cannot be cast to the declared "
+                    f"return type {returnType.simpleString()} under ANSI rules; "
+                    "falling back to interpreted Python"
+                )
         converted = self._convert_chunk(params, function_body[0])
         # Cast to the declared return type so the rewritten plan reports a
         # known data type to the optimizer's plan validator (otherwise it
@@ -876,6 +946,31 @@ def _transpile_func(
     column types, or falls back to the Python UDF when none match.
     """
     try:
+        # The transpiler lowers to atomic (numeric/string/boolean/binary)
+        # expressions and casts the result to the declared return type. For a
+        # return type no lowering can be cast to (arrays, maps, structs,
+        # datetimes, ...), that Cast can never resolve -- and because the
+        # options ride along as children of TranspiledPythonUDF, an
+        # unresolvable Cast fails the WHOLE query at CheckAnalysis instead of
+        # falling back. Restrict transpilation to return types with a valid
+        # ANSI cast from the lowered categories (the per-variant combinations
+        # are checked in ``_transpile_from_ast``); everything else falls back
+        # to interpreted Python.
+        if isinstance(returnType, str):
+            from pyspark.sql.types import _parse_datatype_string
+
+            returnType = _parse_datatype_string(returnType)
+        if not isinstance(returnType, (NumericType, StringType, BooleanType, BinaryType)):
+            return (
+                [],
+                [
+                    f"return type {returnType.simpleString()} is not supported by "
+                    "the transpiler (no lowered expression can be cast to it "
+                    "under ANSI rules); falling back to interpreted Python"
+                ],
+                [],
+                [],
+            )
         # A functools.wraps-style decorator makes ``inspect.getsource`` return
         # the WRAPPED function's source (getsource follows ``__wrapped__``),
         # while the UDF actually executes the wrapper. Transpiling would

--- a/python/pyspark/sql/udf.py
+++ b/python/pyspark/sql/udf.py
@@ -228,58 +228,76 @@ class UserDefinedFunction:
         # Conf values are compared case-insensitively: `SET conf=True` stores
         # the literal "True", which would otherwise silently disable
         # transpilation (or mis-trigger the ANSI warning below).
-        def _conf_is_true(key: str) -> bool:
+        #
+        # Each conf read is a JVM roundtrip, so keep the default construction
+        # path cheap: the experimental gate is only read for deterministic
+        # batched UDFs (the only shape we transpile), and the ANSI conf is only
+        # read once the gate is known to be on. When ``default`` is given it is
+        # passed through to ``RuntimeConfig.get`` so construction never depends
+        # on the JVM having the (experimental) conf registered -- e.g. a newer
+        # Python client against an older driver. No default is passed for
+        # ``spark.sql.ansi.enabled``: its registered default is dynamic
+        # (environment-driven) and must be respected when the key is unset.
+        def _conf_is_true(key: str, default: Optional[str] = None) -> bool:
             if session is None:
                 return False
-            value = session.conf.get(key)
+            if default is None:
+                value = session.conf.get(key)
+            else:
+                value = session.conf.get(key, default)
             return value is not None and value.lower() == "true"
 
-        transpile_enabled = (
-            deterministic
-            and evalType == PythonEvalType.SQL_BATCHED_UDF
-            and _conf_is_true("spark.sql.experimental.optimizer.transpilePyUDFs")
-        )
-        ansi_enabled = _conf_is_true("spark.sql.ansi.enabled")
-        # Transpilation only attempts to reproduce ANSI-mode Spark SQL semantics
-        # (no silent integer overflow, divide-by-zero raises, etc.). Running it
-        # against non-ANSI Spark would balloon the test matrix we'd have to
-        # maintain to verify Python-vs-SQL equivalence, so we gate on ANSI here
-        # and warn the user instead of trying to transpile in a mode we don't
-        # claim to support yet.
-        if transpile_enabled and not ansi_enabled:
-            warnings.warn(
-                "Python UDF transpilation "
-                "(spark.sql.experimental.optimizer.transpilePyUDFs) is only "
-                "supported when ANSI mode is enabled "
-                "(spark.sql.ansi.enabled=true). Skipping transpilation for "
-                f"{func} -- enable ANSI mode or set transpilePyUDFs=false to "
-                "silence this warning.",
-                RuntimeWarning,
+        try:
+            transpile_enabled = (
+                deterministic
+                and evalType == PythonEvalType.SQL_BATCHED_UDF
+                and _conf_is_true("spark.sql.experimental.optimizer.transpilePyUDFs", "false")
             )
-            transpile_enabled = False
-        if transpile_enabled and session:
-            # Import only if needed, also avoid circular import loops.
-            from pyspark.sql.transpile import _transpile_func
+            # Transpilation only attempts to reproduce ANSI-mode Spark SQL
+            # semantics (no silent integer overflow, divide-by-zero raises,
+            # etc.). Running it against non-ANSI Spark would balloon the test
+            # matrix we'd have to maintain to verify Python-vs-SQL equivalence,
+            # so we gate on ANSI here and warn the user instead of trying to
+            # transpile in a mode we don't claim to support yet.
+            if transpile_enabled and not _conf_is_true("spark.sql.ansi.enabled"):
+                warnings.warn(
+                    "Python UDF transpilation "
+                    "(spark.sql.experimental.optimizer.transpilePyUDFs) is only "
+                    "supported when ANSI mode is enabled "
+                    "(spark.sql.ansi.enabled=true). Skipping transpilation for "
+                    f"{func} -- enable ANSI mode or set transpilePyUDFs=false to "
+                    "silence this warning.",
+                    RuntimeWarning,
+                )
+                transpile_enabled = False
+            if transpile_enabled and session:
+                # Import only if needed, also avoid circular import loops.
+                from pyspark.sql.transpile import _transpile_func
 
-            try:
+                # ``self.returnType`` parses (and caches) the declared return
+                # type; the transpiler needs the parsed form to decide whether
+                # the final Cast to it can resolve at all. The parse is reused
+                # later by ``_create_judf``, so this adds no extra JVM work.
                 (
                     self.transpiled,
                     errors,
                     self._transpiled_param_names,
                     self._transpiled_input_categories,
-                ) = _transpile_func(session, func, returnType)
+                ) = _transpile_func(session, func, self.returnType)
                 if not self.transpiled:
                     detail = f": {errors}" if errors else ""
                     warnings.warn(f"Unable to transpile UDF {func}{detail}")
-            except Exception as e:
-                # An inability to transpile must never break a working
-                # UDF -- fall back to interpreted Python execution and
-                # surface the failure as a warning so users can opt to
-                # investigate without losing their query.
-                warnings.warn(f"Exception transpiling UDF {func}: {e}")
-                self.transpiled = []
-                self._transpiled_param_names = []
-                self._transpiled_input_categories = []
+        except Exception as e:
+            # An inability to transpile must never break a working UDF -- fall
+            # back to interpreted Python execution and surface the failure as a
+            # warning so users can opt to investigate without losing their
+            # query. The conf reads above are included: a session whose JVM
+            # cannot answer them should degrade to "no transpilation", not
+            # break UDF definition.
+            warnings.warn(f"Exception transpiling UDF {func}: {e}")
+            self.transpiled = []
+            self._transpiled_param_names = []
+            self._transpiled_input_categories = []
 
     @staticmethod
     def _check_return_type(returnType: DataType, evalType: int) -> None:


### PR DESCRIPTION
## Summary
This PR hardens the Python UDF transpilation feature by adding comprehensive safety checks to prevent invalid transpilations that would cause query failures or silent result divergences instead of gracefully falling back to interpreted Python execution.

## Key Changes

### Transpilation Safety Checks
- **Return type validation**: Reject transpilation for return types that no lowering can category-match (arrays, maps, structs, datetimes, etc.). These would cause `CheckAnalysis` to fail on the entire query instead of falling back.
- **Strict return-category matching (per Codex review)**: Each variant requires its body category to *match* the declared return type's category (numeric -> non-decimal NumericType, string -> StringType, bool -> BooleanType, binary -> BinaryType). Analysis-valid cross-category casts (e.g. `string -> long`, `numeric -> boolean`) are rejected too: the interpreted `SQL_BATCHED_UDF` path nulls type-mismatched results (`EvaluatePython.makeFromJava`), so a lowered cast would silently return converted values (or raise `CAST_INVALID_INPUT`) where interpreted returns NULL. Within-numeric conversions (bigint body cast to double return) remain allowed and are pinned by `test_udf_transpile_casts_to_return_type`.
- **Unary operator type checking**: Restrict unary `+`/`-` operators to numeric operands only. Python raises `TypeError` on strings, but Spark's ANSI string promotion would silently coerce them. Boolean operands would fail analysis outright.
- **Self-reference detection**: Reject transpilation of callable bodies that reference bare `self`, which would previously emit invalid `_udf_param_-1` parameter references and throw an AnalysisException at call construction.

### If-Statement Category Inference
- Added `_safe_category` handling for `ast.If` nodes to properly infer the category of conditional bodies based on their branches' common category (the numeric catch-all previously mislabeled every if-statement).

### Configuration Optimization
- Optimized JVM roundtrips in UDF initialization: the ANSI conf is read only once the transpile gate is known to be on, and the gate is read with an explicit default so construction never depends on the experimental conf being registered in older drivers.
- Conf reads moved inside the never-break-a-working-UDF try block.

## Implementation Details

The transpiler lowers Python UDFs to atomic (numeric/string/boolean/binary) expressions and casts the result to the declared return type. When the body category does not match the return type's category, that cast either fails `CheckAnalysis` (as a child of `TranspiledPythonUDF`, before `ConvertToCatalyst` can drop it, breaking the entire query) or silently diverges from the interpreted converter's null-on-mismatch behavior. These changes ensure such cases fall back to interpreted Python instead.

All new safety checks are validated with unit tests covering:
- Uncastable return types (arrays, timestamps)
- Cross-category return casts, including the analysis-valid ones (string body declared long, numeric body declared boolean/decimal, binary body declared string) with an interpreted-NULL execution check
- Non-numeric unary operators on strings and booleans
- Self-references in callable bodies (constructed UDF falls back and executes interpreted)

https://claude.ai/code/session_01EL539J8Fr5JgeKrJBqydiR